### PR TITLE
Use async DataRouter in services

### DIFF
--- a/tests/test_library_interface.py
+++ b/tests/test_library_interface.py
@@ -95,7 +95,10 @@ class TestVPrismClient:
         assert query.symbols == ["000001"]
         assert query.timeframe == TimeFrame.DAY_1
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     @pytest.mark.asyncio
     async def test_execute_query(self, mock_get_data, mock_route_query):
@@ -114,7 +117,10 @@ class TestVPrismClient:
         mock_provider.get_data.assert_called_once_with(query)
         assert result == {"data": "test"}
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     def test_get_sync(self, mock_get_data, mock_route_query):
         """测试同步获取数据"""
@@ -133,7 +139,10 @@ class TestVPrismClient:
 
         assert result == {"data": "sync_test"}
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     @pytest.mark.asyncio
     async def test_get_async(self, mock_get_data, mock_route_query):
@@ -152,7 +161,10 @@ class TestVPrismClient:
 class TestGlobalInterface:
     """测试全局接口"""
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     def test_global_get(self, mock_get_data, mock_route_query):
         """测试全局get函数"""
@@ -168,7 +180,10 @@ class TestGlobalInterface:
 
         assert result == {"data": "mock_data"}
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     @pytest.mark.asyncio
     async def test_global_get_async(self, mock_get_data, mock_route_query):
@@ -181,7 +196,10 @@ class TestGlobalInterface:
 
         assert result == {"data": "mock_async_data"}
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     def test_global_query_and_execute(self, mock_get_data, mock_route_query):
         """测试全局query和execute函数"""
@@ -228,7 +246,10 @@ class TestErrorHandling:
             client = VPrismClient()
             client.get(asset="stock", market="cn", symbols=["000001"], timeframe="invalid")
 
-    @patch("vprism.core.services.data_router.DataRouter.route_query")
+    @patch(
+        "vprism.core.services.routing.DataRouter.route_query",
+        new_callable=AsyncMock,
+    )
     @patch("vprism.core.data.providers.base.DataProvider.get_data")
     def test_empty_symbols(self, mock_get_data, mock_route_query):
         """测试空股票代码列表"""

--- a/vprism/core/client/client.py
+++ b/vprism/core/client/client.py
@@ -35,7 +35,7 @@ class VPrismClient:
 
         # 初始化核心组件
         from vprism.core.data.providers.registry import ProviderRegistry
-        from vprism.core.services.data_router import DataRouter
+        from vprism.core.services.routing import DataRouter
 
         self.registry = ProviderRegistry()
         self.router = DataRouter(self.registry)
@@ -83,7 +83,7 @@ class VPrismClient:
         if not self._configured:
             self._apply_config()
 
-        provider = self.router.route_query(query)
+        provider = await self.router.route_query(query)
         return await provider.get_data(query)
 
     def get(

--- a/vprism/core/services/batch.py
+++ b/vprism/core/services/batch.py
@@ -12,7 +12,7 @@ from vprism.core.models.market import AssetType, MarketType, TimeFrame
 from vprism.core.models.query import DataQuery
 from vprism.core.models.response import DataResponse
 from vprism.core.services.data import DataService
-from vprism.core.services.data_router import DataRouter
+from vprism.core.services.routing import DataRouter
 
 logger = logging.getLogger(__name__)
 

--- a/vprism/core/services/data.py
+++ b/vprism/core/services/data.py
@@ -15,7 +15,7 @@ from vprism.core.models.market import AssetType, MarketType, TimeFrame
 from vprism.core.models.query import DataQuery
 from vprism.core.models.response import DataResponse, ProviderInfo, ResponseMetadata
 from vprism.core.monitoring import PerformanceLogger, bind
-from vprism.core.services.data_router import DataRouter
+from vprism.core.services.routing import DataRouter
 
 
 class DataService:


### PR DESCRIPTION
## Summary
- use async DataRouter across services and client
- await router in VPrismClient.execute
- improve AkShare import error chaining
- clarify consistency check filtering
- update tests to patch async DataRouter

## Testing
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run mypy ./vprism` *(fails: Missing fastapi and loguru type stubs)*
- `uv run pytest tests/test_library_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68a48ced9610832dbfe6f86bee6bcdfd