### PR TITLE
Update PRD-2 scope and milestones

### DIFF
--- a/docs/prd/PRD-2.md
+++ b/docs/prd/PRD-2.md
@@ -14,20 +14,18 @@ Problem Statement
 
 Scope
 Must:
-- Ingestion API ingest(records: Iterable[RawRecord], provider:str, market:str) -> IngestionResult
+- Ingestion API ingest(records: Iterable[RawRecord], provider:str, market:str) 将通过校验的记录写入 raw_ohlcv，并补充 batch_id(UUIDv4) 与 ingest_time
 - RawRecord 模型 (supplier_symbol,timestamp,open,high,low,close,volume,provider)
 - DuckDB 表 raw_ohlcv(supplier_symbol,market,ts,open,high,low,close,volume,provider,batch_id,ingest_time)
-- 基础校验: 字段非空(open..close,volume允许0), OHLC一致 open<=high>=low<=high, low<=open/close<=high, volume>=0
+- 基础校验: 字段非空(open..close,volume允许0), 数值有限, OHLC 关系 low<=open/close<=high, volume>=0
 - 时间校验: 同 batch 内 timestamp 严格递增或非降序 (configurable)
-- Null & 校验失败行统计并剔除写入
-- IngestionResult {written_rows,rejected_rows,fail_reasons[],batch_id,duration_ms}
-- batch_id 生成 UUIDv4
-- 结构化错误类型: ValidationError(detail=list[FieldIssue])
-- 单元测试: 通过/失败/部分拒绝/时间逆序/极值边界
 Should:
 - 重复行检测 (supplier_symbol,market,ts) 去重策略 (忽略写入计为 duplicate_count)
 - 配置对象 IngestionConfig(max_batch_rows, enforce_monotonic_ts, allow_duplicate)
 - 性能计时 metrics stub
+- Null & 校验失败行统计并剔除写入
+- IngestionResult {written_rows,rejected_rows,fail_reasons[],batch_id,duration_ms}
+- 结构化错误类型: ValidationError(detail=list[FieldIssue])
 Could:
 - 并行分片校验 (后期)
 - Provider 自动重试(指数退避 3 次)
@@ -60,14 +58,14 @@ R2 数值范围: open,high,low,close 为有限数 (非 NaN/Inf)
 R3 OHLC 关系: low <= open <= high AND low <= close <= high AND low <= high
 R4 Volume>=0 (缺失→0 可配置?)
 R5 Timestamp 单调: ts[i] >= ts[i-1] (enforce_monotonic_ts=True)
-R6 Duplicate 策略: 如果存在相同 (symbol,market,ts) 且不同 batch → 允许; 同 batch 冲突 → 保留首行
+R6 Duplicate 策略（Milestone 1）: 如果存在相同 (symbol,market,ts) 且不同 batch → 允许; 同 batch 冲突 → 保留首行
 
 Algorithm (ingest)
 1 start timer; gen batch_id
-2 iterate records: validate -> accumulate valid_rows / rejected_rows
-3 deduplicate (in-memory set) if configured
+2 iterate records: validate -> 将记录区分为 valid_rows / rejected_rows
+3 （Milestone 1）deduplicate (in-memory set) if configured
 4 bulk insert (DuckDB executemany) inside transaction
-5 produce IngestionResult + metrics emit stub
+5 （Milestone 1）produce IngestionResult + metrics emit stub
 
 Metrics (Later Prometheus Bridge)
 - ingestion_rows_total{provider,market}
@@ -75,7 +73,7 @@ Metrics (Later Prometheus Bridge)
 - ingestion_duration_ms_histogram
 - ingestion_duplicates_total
 
-Error Model
+Error Model（Milestone 1）
 ValidationError: issues=[{field, code, message, value?}]
 IngestionConfigError: 配置非法时抛出
 
@@ -84,15 +82,18 @@ Performance Targets
 - 内存占用 < 30MB (10k 记录暂存)
 
 Testing Strategy
+Milestone 0
 - test_valid_batch_all_written
 - test_missing_field_rejected
 - test_ohlc_violation_rejected
 - test_volume_negative_rejected
 - test_timestamp_non_monotonic_when_enforced
 - test_timestamp_non_monotonic_not_enforced
+Milestone 1
 - test_duplicate_same_batch_deduped
-- test_large_batch_performance (标记 perf)
 - test_partial_rejection_counts
+Milestone 2
+- test_large_batch_performance (标记 perf)
 
 Open Questions
 - volume 缺失是否填 0 或拒绝 (假设填 0 并加 flag?)
@@ -101,10 +102,13 @@ Open Questions
 - 允许浮点精度保留还是四舍五入 (默认保持原值)
 
 Acceptance Criteria
-- 任一规则违反对应 rejected_rows 递增 & fail_reasons 聚合
-- 成功写入行数 = 输入 - rejected
-- 覆盖率≥80%，异常分支均被测试
-- 执行 ingestion 示例日志包含 batch_id & stats
+Milestone 0
+- 违反基础校验/时间规则的记录全部拒绝写入，写入行数 = 输入 - rejected
+- 覆盖率≥80%，基础校验与异常分支具备单测
+- 执行 ingestion 示例日志包含 batch_id 与写入行数
+Milestone 1
+- 提供 rejected_rows 统计与 fail_reasons 聚合
+- IngestionResult 输出 written_rows/rejected_rows/fail_reasons/batch_id/duration_ms
 
 Risks & Mitigations
 - 大批内存峰值 → 流式校验+缓写 (后续优化)
@@ -112,12 +116,18 @@ Risks & Mitigations
 - 浮点不精确影响比较 → 使用 <=/>= 容差阈值 epsilon=1e-12
 
 Rollout Plan
-Phase 1: 同步单线程实现 + 基础规则
-Phase 2: Duplicate 检测/索引 & Metrics hook
-Phase 3: 并发/分片 & backoff 重试
+Milestone 0: Validated write path 到 raw_ohlcv（完成 Must 范围）
+  - 最终确定 RawRecord/raw_ohlcv schema 并创建表
+  - 实现 ingest() 流程，执行基础字段/时间校验，仅将通过校验的记录持久化
+  - 覆盖“全部通过 / 校验失败 / 时间逆序”等基础场景的测试
+Milestone 1: Duplicate 检测/索引、结构化错误模型 & Metrics hook
+Milestone 2: 并发/分片 & backoff 重试
 
 Next Steps
-1 定义 RawRecord/ValidationIssue/IngestionResult 数据模型
-2 实现校验器 validator(record)->list[Issue]
-3 编写 ingestion 事务写入函数 + tests
-4 引入 IngestionConfig + duplicate 逻辑
+Milestone 0
+1 定义 RawRecord 数据模型与 raw_ohlcv 表 schema
+2 实现基础校验器 validator(record)->list[Issue]
+3 编写 ingestion 事务写入函数 + 基础场景 tests
+Milestone 1
+4 扩展 ValidationIssue/IngestionResult & rejected_rows 聚合
+5 引入 IngestionConfig + duplicate 逻辑


### PR DESCRIPTION
## Summary
- narrow the PRD-2 Must scope to schema creation, core ingestion flow, and basic field/time validation
- move deduplication and structured error modelling expectations into the Should phase
- add an explicit Milestone 0 plan that targets writing validated rows into the `raw_ohlcv` table and reorganize downstream milestones, tests, and acceptance criteria accordingly

## Testing
- `uv run pytest` *(fails: external data providers reject SSL handshakes in the test environment)*
- `uv run ruff check .` *(fails: existing TC00x import location issues in vprism/core/models/corporate_actions.py and import sorting in services)*
- `uv run ruff format .`
- `uv run mypy ./vprism` *(fails: mypy parser requires Python 3.13 support for vprism/core/data/repositories/base.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c97b5d5578832da49a625da68a298a