### PR TITLE
docs: formalize corporate action formulas

### DIFF
--- a/docs/prd/PRD-3.md
+++ b/docs/prd/PRD-3.md
@@ -66,10 +66,34 @@ Computation Overview
 5 写 adjustments 因子行 (每日期一个)
 6 合并输出 adjusted close 列
 
-Adjustment Formulas (简化)
-- split_ratio r: 价格除以 r, 因子乘以 r (hfq 累乘)
-- dividend_cash d: qfq 常见处理 (price_{prev} = price_{curr} + d) 影响前序因子
-  (实际公式需确认：暂采用 国内常规前复权算法: 前价 = 后价 * (前收盘价 - 现金红利) / 前收盘价)
+Adjustment Formulas
+- 定义符号:
+  - \(P_t\): 有效日 \(t\) 的原始收盘价 (未复权)
+  - \(D_t\): 有效日 \(t\) 对应的每股现金股息 (若无则为 0)
+  - \(r_t\): 拆分/合并后与除权前的股数比 (如 2:1 拆分则 \(r_t = 2\))
+  - \(F^{hfq}_t\): 后复权累计因子，基础日初始为 1
+  - \(F^{qfq}_t\): 前复权累计因子，等于 \(F^{hfq}_t / F^{hfq}_{\text{latest}}\)
+- 股票拆分/合并 (split_ratio): 依照美国市场对价调整约定，除权价会按比例缩放，例如 2-for-1 拆分后价格除以 2，所以 \(F^{hfq}_t = F^{hfq}_{t^-} \times r_t\)，\(F^{qfq}_t = F^{qfq}_{t^+} / r_t\)。[^1]
+- 现金分红 (cash dividend): 交易所在除息日将价格下调约等于股息额，等价于用除权价 \(P_t\) 与股息 \(D_t\) 计算连贯比值，因此 \(F^{hfq}_t = F^{hfq}_{t^-} / (1 - D_t / P_{t^-})\)，\(F^{qfq}_t = F^{qfq}_{t^+} \times (1 - D_t / P_{t^-})\)。[^2]
+- 因子应用: 复权价采用主流数据供应商的公式 \(\text{price}^{adj}_t = P_t \times F^{qfq}_t + \text{adjust}_t\) (若 adjust 为 0 则为简单乘积)；如需后复权价格，可直接使用 \(P_t \times F^{hfq}_t\)。[^3]
+- 因子构建方式遵循国内券商/聚宽数据的“现金红利再投资 + 动态复权”惯例，`adj='qfq'|'hfq'` 按设定的截止日期重新计算，保证现价或首日价格稳定，便于与国内 A 股行情比对。[^4]
+
+Dividend & Split Example
+
+日期 | 事件 | 原始收盘价 | 说明 | \(F^{hfq}\) | \(F^{qfq}\) | 后复权价 | 前复权价
+---|---|---|---|---|---|---|---
+2024-01-01 | 无 | 100.00 | 基准日 | 1.0000 | 0.4902 | 100.00 | 49.02
+2024-01-02 | 现金分红 2.00 | 98.00 | 除息日 \(D=2\) | 1.0204 | 0.5000 | 100.00 | 49.00
+2024-01-03 | 拆分 2:1 | 49.00 | 拆分比 \(r=2\) | 2.0408 | 1.0000 | 100.00 | 49.00
+
+计算说明:
+- 2024-01-02: \(F^{hfq}_{t} = 1/(1-2/100) = 1.0204\)，后复权价保持 100；\(F^{qfq}_t = 1.0204 / 2.0408 = 0.5000\)。
+- 2024-01-03: \(F^{hfq}_t = 1.0204 \times 2 = 2.0408\) 使拆分后的 49 元回推为 100 元；最新日期定义为 \(F^{qfq}=1\)。
+- 历史前复权价通过 \(P_t \times F^{qfq}_t\) 得到 2024-01-01 ≈ 49.02，连续于最新价。
+
+Multi-currency Events
+
+- 国内常用数据接口仅对单币种股票提供复权 (Tushare `pro_bar` 仅对 `asset='E'` 股票执行 qfq/hfq，且按照截止日动态复权)，多币种股息需先换算至报价货币。当前阶段统一将多币种企业行为标记为待办，在 Out of Scope 中维持 FX 调整缺省策略，后续版本再引入跨币种汇率支持。[^4]
 
 Versioning
 algorithm_version = 1 (初始)
@@ -119,3 +143,10 @@ Next Steps
 2 实现 compute pipeline (单 symbol)
 3 添加组合事件测试用例
 4 CLI 接入 (后续 PRD-5)
+
+References
+[^1]: Stock split – Wikipedia. https://en.wikipedia.org/wiki/Stock_split
+[^2]: Dividend – Wikipedia. https://en.wikipedia.org/wiki/Dividend
+[^3]: AKShare Stock Data Manual. https://akshare.akfamily.xyz/data/stock/stock.html
+[^4]: Tushare Pro `pro_bar` 接口说明. https://tushare.pro/document/2?doc_id=109
+


### PR DESCRIPTION
## Summary
- replace placeholder dividend/split guidance with explicit qfq/hfq factor formulas tied to market conventions
- add a worked dividend-plus-split example demonstrating factor propagation
- document the deferral of multi-currency corporate actions and cite relevant data provider practices

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca25fa9154832db544e0d366aa146c