### PR TITLE
Document reconciliation calendar and pricing configuration

### DIFF
--- a/docs/prd/PRD-6.md
+++ b/docs/prd/PRD-6.md
@@ -30,6 +30,14 @@ Algorithm
 5 聚合统计写 reconciliation_runs + 明细写 diffs
 6 返回结果对象 (包含聚合 + 前若干 fail 样本)
 
+Calendar & Pricing Policy
+- Calendar Source: 使用 `exchange_calendars` 官方交易日历，根据 `market` 映射至具体交易所（如 `cn` → `XSHG`, `us` → `XNYS`），统一生成[start, end] 范围内的交易日集合。
+- Holiday Handling: 仅在生成的交易日集合上对齐数据。若某 Provider 在交易日缺失数据 → 触发 `missing_source_x` 并将该 symbol/date 计为 FAIL；若返回非交易日数据 → 丢弃该行并记录数据质量告警。
+- Price Basis: 使用 raw close（未复权）进行对账，理由：
+  - yfinance/akshare 对复权口径实现差异大，直接比较易产生系统性噪音；
+  - 业务方消费对账结果时主要关注交割价差，而非复权收益率；
+  - 复权需求由上游数据清洗流程负责，该服务保持输入原始性。
+
 Metrics (Later)
 - reconciliation_fail_rate
 - reconciliation_avg_bp_diff
@@ -45,9 +53,13 @@ Testing Strategy
 - 一方无数据 → 全 FAIL + missing 标记
 - 混合场景统计计数正确
 
+Configuration
+- `calendar.market_map`: `{ "cn": "XSHG", "us": "XNYS" }` 等映射，默认使用 `exchange_calendars`。可扩展至其他市场；缺省时回退至 `XNYS`。
+- `calendar.strict_trading_days`: bool，默认 `true`，控制是否强制仅在官方交易日对齐数据；关闭时保留 Provider 自带日期。
+- `pricing.price_mode`: 枚举 `raw` / `adjusted`，默认 `raw`。如需对复权口径对账，需在运行前显式切换并确保两数据源复权方式一致。
+- `pricing.missing_fill`: 可选策略 `none`（默认）/`forward_fill`，用于调试环境；生产禁止启用填充以避免掩盖缺口。
+
 Open Questions
-- 是否需要对齐企业行为调整后价格 (当前使用 raw close)
-- 是否需要过滤节假日 (使用交易日日历) (Must for准确)
 - 采样策略是否增加 stratified by market segment (当前不做)
 
 Acceptance Criteria


### PR DESCRIPTION
## Summary
- document the reconciliation calendar source and holiday handling approach
- record the decision to reconcile on raw close prices with supporting rationale
- add configuration guidance covering calendar mappings and pricing adjustment settings

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca25fb0e68832db20cb3d19c5a0f43