### PR TITLE
Implement adjustment engine and corporate action schema

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -1,0 +1,1586 @@
+{
+  "detected_prd_files": [
+    "docs/prd/PRD-0.md",
+    "docs/prd/PRD-1.md",
+    "docs/prd/PRD-2.md",
+    "docs/prd/PRD-3.md",
+    "docs/prd/PRD-4.md",
+    "docs/prd/PRD-5.md",
+    "docs/prd/PRD-6.md",
+    "docs/prd/PRD-7.md",
+    "docs/prd/PRD-8.md",
+    "docs/prd/PRD-9.md"
+  ],
+  "clarification_questions": [],
+  "plan": {
+    "summary": {
+      "total": 53,
+      "todo": 35,
+      "in_progress": 0,
+      "done": 18,
+      "prd_count": 10
+    },
+    "tasks": [
+      {
+        "id": "PRD-0-001",
+        "title": "Establish core OHLCV schema module with creation helpers",
+        "description": "Define raw and normalized schema structures in a dedicated module with helpers covering the required columns for raw_schema and normalization_schema to serve as the baseline for downstream features.",
+        "source_prd_path": "docs/prd/PRD-0.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "tests/core/data/test_schema_module.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "raw_schema",
+              "columns": [
+                "supplier_symbol",
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "provider"
+              ]
+            },
+            {
+              "name": "normalization_schema",
+              "columns": [
+                "supplier_symbol",
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "provider",
+                "market",
+                "tz_offset",
+                "currency",
+                "c_symbol"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Unit test verifying create_ddl() outputs include required columns for raw and normalization schemas.",
+          "Ensure schema helpers integrate with DuckDB connection in tests."
+        ],
+        "dependencies": [],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove newly added schema module and related tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "Baseline raw/normalization schema tables created with DuckDB helpers; validated via pytest tests/core/data/test_schema_module.py"
+      },
+      {
+        "id": "PRD-0-002",
+        "title": "Implement schema assertion helpers for raw and normalized datasets",
+        "description": "Provide reusable assertion utilities that validate presence and types of required columns and raise structured errors when fields are missing, enabling acceptance tests to verify failure handling.",
+        "source_prd_path": "docs/prd/PRD-0.md",
+        "code_targets": [
+          "vprism/core/validation/schema_assertions.py",
+          "tests/core/validation/test_schema_assertions.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests covering success when schemas match expectations.",
+          "Negative tests asserting structured exceptions when required columns are absent."
+        ],
+        "dependencies": [
+          "PRD-0-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Delete schema assertion helper module and its tests.",
+        "effort": "S",
+        "status": "DONE",
+        "completion_note": "Schema assertion helpers validate required columns, types, and constraints; covered by pytest tests/core/validation/test_schema_assertions.py"
+      },
+      {
+        "id": "PRD-0-003",
+        "title": "Create provider stub and ingestion sample test for raw schema",
+        "description": "Implement a stub data provider capable of injecting fake records and write sample ingestion tests that confirm valid rows land in the raw table and invalid rows trigger structured failures.",
+        "source_prd_path": "docs/prd/PRD-0.md",
+        "code_targets": [
+          "vprism/core/data/providers/stub_provider.py",
+          "tests/core/data/test_stub_provider_ingestion.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Integration-style test asserting stub rows persist into DuckDB via ingestion pipeline.",
+          "Test that missing-field rows surface structured exceptions."
+        ],
+        "dependencies": [
+          "PRD-0-001",
+          "PRD-0-002"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove stub provider implementation and related tests.",
+        "effort": "S",
+        "status": "DONE",
+        "completion_note": "Stub provider seeds raw_schema and surfaces validation errors; verified via pytest tests/core/data/test_stub_provider_ingestion.py"
+      },
+      {
+        "id": "PRD-0-004",
+        "title": "Introduce DuckDB connection factory utility for tests and local runs",
+        "description": "Add a lightweight connection factory (context manager or helper) to provision single-threaded DuckDB instances suited for unit and integration tests per baseline scope.",
+        "source_prd_path": "docs/prd/PRD-0.md",
+        "code_targets": [
+          "vprism/core/data/storage/duckdb_factory.py",
+          "tests/core/data/test_duckdb_factory.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit test verifying factory yields a working DuckDB connection and cleans up resources.",
+          "Ensure factory can initialize in-memory databases for ingestion tests."
+        ],
+        "dependencies": [],
+        "risk_note": "LOW",
+        "rollback_hint": "Delete DuckDB factory utility and associated tests.",
+        "effort": "S",
+        "status": "DONE",
+        "completion_note": "DuckDB factory context manager and connection helper verified via pytest tests/core/data/test_duckdb_factory.py"
+      },
+      {
+        "id": "PRD-1-001",
+        "title": "Implement SymbolService rule engine with caching and diagnostics",
+        "description": "Build SymbolService with Rule dataclass support, LRU cache (10k default), deterministic normalize method, structured UnresolvedSymbolError diagnostics, and in-memory counters for total, cache hits, cache misses, and unresolved symbols.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/services/symbols.py",
+          "vprism/core/models/symbols.py",
+          "tests/core/services/test_symbol_service.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [
+          {
+            "method": "function",
+            "path": "SymbolService.normalize",
+            "req_schema": "{raw_symbol: str, market: MarketType, asset_type: AssetType}",
+            "resp_schema": "CanonicalSymbol",
+            "status_codes": []
+          }
+        ],
+        "test_plan": [
+          "Unit tests for successful normalization, cache hit behavior, and diagnostics on misses.",
+          "Rule priority ordering tests ensuring first applicable rule short-circuits."
+        ],
+        "dependencies": [],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Revert SymbolService implementation and related tests.",
+        "effort": "L",
+        "status": "DONE",
+        "completion_note": "SymbolService implements rule-based normalization with caching and diagnostics; covered by pytest tests/core/services/test_symbol_service.py"
+      },
+      {
+        "id": "PRD-1-002",
+        "title": "Define built-in normalization rule set for CN stock/fund/index",
+        "description": "Add the confirmed baseline rule definitions (priority, pattern, transforms) for CN stocks, funds, and indices so that default normalization covers Phase 1 scope with deterministic canonical symbols, referencing yfinance and akshare public formats for validation.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/services/symbols.py",
+          "tests/core/services/test_symbol_rules.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Parameterized tests covering provided stock, fund, and index samples derived from yfinance and akshare references hitting expected rules.",
+          "Negative tests for unresolved symbols producing UnresolvedSymbolError with diagnostics."
+        ],
+        "dependencies": [
+          "PRD-1-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove built-in rule definitions and adjust tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "Default CN stock/fund/index rules align with yfinance and akshare formats; verified via pytest tests/core/services/test_symbol_rules.py"
+      },
+      {
+        "id": "PRD-1-003",
+        "title": "Expose normalization metrics and cache introspection",
+        "description": "Implement metrics export API (get_metrics) returning hit rate, misses, and rule usage counters for observability while keeping state in memory per Phase 1 scope.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/services/symbols.py",
+          "tests/core/services/test_symbol_metrics.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit test verifying metrics reflect cache hit and miss behavior after sequential calls.",
+          "Test rule usage counters increment per matched rule."
+        ],
+        "dependencies": [
+          "PRD-1-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove metrics export method and related tests.",
+        "effort": "S",
+        "status": "DONE",
+        "completion_note": "SymbolService.get_metrics exposes cache stats, hit rate, unresolved counters, and rule usage validated via pytest tests/core/services/test_symbol_metrics.py"
+      },
+      {
+        "id": "PRD-1-004",
+        "title": "Implement rule reload mechanism with atomic swap",
+        "description": "Provide reload(new_rules) support that validates incoming rule sets, atomically swaps the registry, and resets caches as outlined in Should requirements.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/services/symbols.py",
+          "tests/core/services/test_symbol_reload.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit test ensuring reload swaps to new rules and new calls use updated mapping.",
+          "Verify cache state resets (or follows defined policy) post reload."
+        ],
+        "dependencies": [
+          "PRD-1-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove reload functionality and associated tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "reload() swaps rule sets, clears caches, and resets usage counters; validated via pytest tests/core/services/test_symbol_reload.py"
+      },
+      {
+        "id": "PRD-1-005",
+        "title": "Persist canonical mappings to DuckDB symbol_map table",
+        "description": "Create symbol_map DuckDB schema and write logic to insert first-time successful normalizations (INSERT OR IGNORE) capturing rule_id, provider hints, and timestamps for auditability.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "vprism/core/services/symbols.py",
+          "tests/core/services/test_symbol_persistence.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "symbol_map",
+              "columns": [
+                "c_symbol",
+                "raw_symbol",
+                "market",
+                "asset_type",
+                "provider_hint",
+                "rule_id",
+                "created_at"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Integration test verifying first-time normalization writes a row and subsequent calls skip duplicates.",
+          "Test schema creation helper produces expected table definition."
+        ],
+        "dependencies": [
+          "PRD-0-001",
+          "PRD-0-004",
+          "PRD-1-002"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Drop symbol_map schema changes and revert persistence hooks.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "SymbolService persists canonical mappings to DuckDB with INSERT OR IGNORE semantics and provider hints; validated via pytest tests/core/services/test_symbol_persistence.py"
+      },
+      {
+        "id": "PRD-1-006",
+        "title": "Support normalize_batch with partial success reporting",
+        "description": "Implement batch normalization API returning per-item statuses, successes, and failures, enabling deferred functional requirements for batch workflows while sharing rule definitions from the built-in set.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/services/symbols.py",
+          "tests/core/services/test_symbol_batch.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [
+          {
+            "method": "function",
+            "path": "SymbolService.normalize_batch",
+            "req_schema": "{raw_symbols: list[str], market: MarketType, asset_type: AssetType}",
+            "resp_schema": "BatchNormalizationResult",
+            "status_codes": []
+          }
+        ],
+        "test_plan": [
+          "Unit tests with mixed valid and invalid inputs confirming partial success reporting.",
+          "Ensure batch invocation updates metrics consistently with single normalize."
+        ],
+        "dependencies": [
+          "PRD-1-001",
+          "PRD-1-002"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove batch API and related tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "normalize_batch aggregates partial successes/failures and preserves metrics behaviour; validated via pytest tests/core/services/test_symbol_batch.py"
+      },
+      {
+        "id": "PRD-1-007",
+        "title": "Enable external YAML/JSON rule loading with validation",
+        "description": "Provide loader utilities that parse YAML and JSON rule definitions, validate structure, and feed SymbolService reload while guarding against malformed configurations.",
+        "source_prd_path": "docs/prd/PRD-1.md",
+        "code_targets": [
+          "vprism/core/services/symbol_rule_loader.py",
+          "tests/core/services/test_symbol_rule_loader.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit test loading valid YAML and JSON rule files and applying them via reload.",
+          "Negative test verifying invalid files raise structured validation errors."
+        ],
+        "dependencies": [
+          "PRD-1-004"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove rule loader module and tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "External YAML/JSON rule loader parses template and map_template transforms, with pytest coverage in tests/core/services/test_symbol_rule_loader.py"
+      },
+      {
+        "id": "PRD-2-001",
+        "title": "Align RawRecord model and raw_ohlcv DuckDB schema",
+        "description": "Define RawRecord dataclass and create raw_ohlcv table with columns and primary key matching ingestion requirements, including batch_id and ingest_time fields.",
+        "source_prd_path": "docs/prd/PRD-2.md",
+        "code_targets": [
+          "vprism/core/data/ingestion/models.py",
+          "vprism/core/data/schema.py",
+          "tests/core/data/test_raw_schema.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "raw_ohlcv",
+              "columns": [
+                "supplier_symbol",
+                "market",
+                "ts",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "provider",
+                "batch_id",
+                "ingest_time"
+              ],
+              "primary_key": [
+                "supplier_symbol",
+                "market",
+                "ts",
+                "batch_id"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Schema creation tests ensuring columns and primary key match specification.",
+          "Dataclass tests verifying default behaviors align with ingestion expectations."
+        ],
+        "dependencies": [
+          "PRD-0-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Drop raw_ohlcv schema helpers and related dataclass.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "RawRecord dataclass introduced with optional volume/provider defaults and raw_ohlcv schema validated via pytest tests/core/data/test_raw_schema.py"
+      },
+      {
+        "id": "PRD-2-002",
+        "title": "Implement base validation rules for ingestion batches",
+        "description": "Create validation routines enforcing required fields, finite OHLC values, monotonic timestamps, OHLC relationships, and volume constraints before persistence, treating missing volume as -1 per the confirmed default.",
+        "source_prd_path": "docs/prd/PRD-2.md",
+        "code_targets": [
+          "vprism/core/data/ingestion/validator.py",
+          "tests/core/data/ingestion/test_validator.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests for each validation rule: missing field, NaN, OHLC violations, negative volume, timestamp ordering, and defaulting missing volume to -1.",
+          "Configurable monotonicity tests verifying behavior when enforcement is toggled."
+        ],
+        "dependencies": [
+          "PRD-2-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove validation module and its tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "Validation rules enforce required fields, OHLC constraints, monotonic timestamps, and default missing volume to -1; covered by pytest tests/core/data/ingestion/test_validator.py"
+      },
+      {
+        "id": "PRD-2-003",
+        "title": "Implement ingest API with batch_id and ingest_time management",
+        "description": "Develop ingestion service that validates records, generates UUID batch_id, stamps ingest_time, writes valid rows to raw_ohlcv, and returns structured IngestionResult payloads while applying the -1 volume default when source data omits the field.",
+        "source_prd_path": "docs/prd/PRD-2.md",
+        "code_targets": [
+          "vprism/core/data/ingestion/service.py",
+          "tests/core/data/ingestion/test_ingest_service.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [
+          {
+            "method": "function",
+            "path": "ingest",
+            "req_schema": "{records: Iterable[RawRecord], provider: str, market: str}",
+            "resp_schema": "IngestionResult",
+            "status_codes": []
+          }
+        ],
+        "test_plan": [
+          "End-to-end test confirming valid batches are written and result counters match inputs.",
+          "Tests for rejected records ensuring they do not persist, include -1 volume defaults, and appear in result metadata."
+        ],
+        "dependencies": [
+          "PRD-2-001",
+          "PRD-2-002",
+          "PRD-0-004"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove ingest service implementation and revert tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "Ingestion service validates batches, writes to raw_ohlcv with batch metadata, and aggregates issues; verified via pytest tests/core/data/ingestion/test_ingest_service.py"
+      },
+      {
+        "id": "PRD-2-004",
+        "title": "Add duplicate detection and ingestion configuration support",
+        "description": "Introduce IngestionConfig with duplicate handling, max batch controls, and integrate duplicate suppression counters alongside optional metrics hooks per Milestone 1 scope.",
+        "source_prd_path": "docs/prd/PRD-2.md",
+        "code_targets": [
+          "vprism/core/data/ingestion/config.py",
+          "vprism/core/data/ingestion/service.py",
+          "tests/core/data/ingestion/test_ingest_duplicates.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit test ensuring duplicate records within a batch are suppressed according to config.",
+          "Tests verifying configuration edge cases (max rows, monotonic enforcement toggles)."
+        ],
+        "dependencies": [
+          "PRD-2-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Revert configuration logic and duplicate detection hooks.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "IngestionConfig controls duplicate suppression and limits; exercised by pytest tests/core/data/ingestion/test_ingest_duplicates.py"
+      },
+      {
+        "id": "PRD-2-005",
+        "title": "Extend ingestion reporting with rejection aggregation",
+        "description": "Augment IngestionResult to include rejected_rows counts, fail_reasons aggregation, and validation issue serialization to satisfy Milestone 1 reporting goals, ensuring missing volume defaults to -1 are identified distinctly.",
+        "source_prd_path": "docs/prd/PRD-2.md",
+        "code_targets": [
+          "vprism/core/data/ingestion/service.py",
+          "tests/core/data/ingestion/test_ingest_reporting.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Tests confirming fail_reasons include grouped counts per validation code, including the -1 volume default scenario.",
+          "Verify rejected_rows tally matches number of invalid records."
+        ],
+        "dependencies": [
+          "PRD-2-003",
+          "PRD-2-002"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove reporting enhancements and adjust tests.",
+        "effort": "S",
+        "status": "DONE",
+        "completion_note": "IngestionResult surfaces fail_reasons aggregation and rejection counts; confirmed with pytest tests/core/data/ingestion/test_ingest_reporting.py"
+      },
+      {
+        "id": "PRD-2-006",
+        "title": "Implement ingestion performance regression test for 10k rows",
+        "description": "Add performance-oriented test or benchmark ensuring 10k-record batches validate and insert within the 500ms local target to detect regressions.",
+        "source_prd_path": "docs/prd/PRD-2.md",
+        "code_targets": [
+          "tests/performance/test_ingest_performance.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Benchmark test feeding 10k rows and asserting runtime stays under threshold.",
+          "Record runtime metrics for visibility in CI logs."
+        ],
+        "dependencies": [
+          "PRD-2-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove performance test file.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-3-001",
+        "title": "Define corporate_actions and adjustments DuckDB schemas",
+        "description": "Create tables for corporate_actions and adjustments with specified columns and primary keys to support event storage and factor persistence.",
+        "source_prd_path": "docs/prd/PRD-3.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "tests/core/data/test_corporate_action_schema.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "corporate_actions",
+              "columns": [
+                "market",
+                "supplier_symbol",
+                "event_type",
+                "effective_date",
+                "dividend_cash",
+                "split_ratio",
+                "raw_payload",
+                "source",
+                "batch_id",
+                "ingest_time"
+              ],
+              "primary_key": [
+                "market",
+                "supplier_symbol",
+                "event_type",
+                "effective_date",
+                "batch_id"
+              ]
+            },
+            {
+              "name": "adjustments",
+              "columns": [
+                "market",
+                "supplier_symbol",
+                "date",
+                "adj_factor_qfq",
+                "adj_factor_hfq",
+                "version",
+                "build_time",
+                "source_events_hash"
+              ],
+              "primary_key": [
+                "market",
+                "supplier_symbol",
+                "date",
+                "version"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Schema tests ensuring column definitions and primary keys match specification.",
+          "Migration tests verifying idempotent creation."
+        ],
+        "dependencies": [
+          "PRD-0-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove new table definitions and associated tests.",
+        "effort": "M",
+        "status": "DONE",
+        "completion_note": "Corporate actions and adjustments schema helpers added with DuckDB creation utilities; verified via pytest tests/core/data/test_corporate_action_schema.py"
+      },
+      {
+        "id": "PRD-3-002",
+        "title": "Implement AdjustmentEngine compute pipeline with configurable factors",
+        "description": "Develop AdjustmentEngine.compute to fetch price series and events, accumulate forward and backward factors per standard qfq and hfq formulas, and support selecting among mainstream adjustment formulas through configuration while flagging gaps and emitting adjusted results with version hash generation.",
+        "source_prd_path": "docs/prd/PRD-3.md",
+        "code_targets": [
+          "vprism/core/services/adjustment_engine.py",
+          "vprism/core/models/corporate_actions.py",
+          "tests/core/services/test_adjustment_engine.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [
+          {
+            "method": "function",
+            "path": "AdjustmentEngine.compute",
+            "req_schema": "{symbol: str, market: str, start: date, end: date, mode: Literal['qfq','hfq','none']}",
+            "resp_schema": "AdjustmentResult",
+            "status_codes": []
+          }
+        ],
+        "test_plan": [
+          "Unit tests for single split, single dividend, combined events, and no-event passthrough scenarios across supported formulas.",
+          "Test version hash stability when events are unchanged."
+        ],
+        "dependencies": [
+          "PRD-3-001"
+        ],
+        "risk_note": "HIGH",
+        "rollback_hint": "Revert AdjustmentEngine implementation and tests.",
+        "effort": "L",
+        "status": "DONE",
+        "completion_note": "AdjustmentEngine computes qfq/hfq factors with gap detection and stable versioning; exercised by pytest tests/core/services/test_adjustment_engine.py"
+      },
+      {
+        "id": "PRD-3-003",
+        "title": "Implement corporate action merge and caching utilities",
+        "description": "Add logic to merge same-day events into single computation units and memoize factor results for reuse, aligning with Should requirements for efficiency.",
+        "source_prd_path": "docs/prd/PRD-3.md",
+        "code_targets": [
+          "vprism/core/services/adjustment_engine.py",
+          "tests/core/services/test_adjustment_merge.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Tests verifying same-day dividend and split events merge correctly.",
+          "Ensure cached results return without recomputation when inputs unchanged."
+        ],
+        "dependencies": [
+          "PRD-3-002"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove merge and caching enhancements and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-3-004",
+        "title": "Persist adjustment factors with version hashing",
+        "description": "Write computed qfq and hfq factors into the adjustments table, storing version identifiers derived from event hashes and algorithm mode so each supported formula remains traceable.",
+        "source_prd_path": "docs/prd/PRD-3.md",
+        "code_targets": [
+          "vprism/core/services/adjustment_engine.py",
+          "tests/core/services/test_adjustment_persistence.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Integration test ensuring adjustments table receives one row per price date with correct version per formula mode.",
+          "Test recomputation produces identical version hash when inputs unchanged."
+        ],
+        "dependencies": [
+          "PRD-3-002",
+          "PRD-3-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove persistence step and adjust tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-4-001",
+        "title": "Create quality_metrics table and status encoding",
+        "description": "Add DuckDB quality_metrics schema with required columns and primary key to store quality indicators and status classifications.",
+        "source_prd_path": "docs/prd/PRD-4.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "tests/core/data/test_quality_metrics_schema.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "quality_metrics",
+              "columns": [
+                "date",
+                "market",
+                "supplier_symbol",
+                "metric",
+                "value",
+                "status",
+                "run_id",
+                "created_at"
+              ],
+              "primary_key": [
+                "date",
+                "market",
+                "metric",
+                "run_id",
+                "supplier_symbol"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Schema tests verifying column definitions and primary key constraints.",
+          "Ensure migrations run idempotently."
+        ],
+        "dependencies": [
+          "PRD-0-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Drop table definition changes and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-4-002",
+        "title": "Implement trading calendar provider for gap detection",
+        "description": "Provide calendar utility mapping markets to exchange calendars and returning trading days windows to support GapDetector logic.",
+        "source_prd_path": "docs/prd/PRD-4.md",
+        "code_targets": [
+          "vprism/core/services/calendars.py",
+          "tests/core/services/test_calendar_provider.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests verifying correct calendar selection for supported markets.",
+          "Test fallback behavior when market-specific calendar unavailable."
+        ],
+        "dependencies": [],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove calendar provider module and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-4-003",
+        "title": "Implement GapDetector writing gap_ratio metrics",
+        "description": "Develop GapDetector to compute expected versus observed trading days, derive gap_ratio, and write metric rows with run metadata into quality_metrics.",
+        "source_prd_path": "docs/prd/PRD-4.md",
+        "code_targets": [
+          "vprism/core/services/quality/gap_detector.py",
+          "tests/core/services/quality/test_gap_detector.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests for scenarios with missing days verifying gap_ratio values.",
+          "Ensure metrics rows persist with correct status classification."
+        ],
+        "dependencies": [
+          "PRD-4-001",
+          "PRD-4-002",
+          "PRD-2-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove gap detector implementation and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-4-004",
+        "title": "Implement DuplicateDetector and metric persistence",
+        "description": "Create DuplicateDetector that aggregates duplicate counts per (symbol, market, date) and records metrics with thresholds for WARN and FAIL statuses.",
+        "source_prd_path": "docs/prd/PRD-4.md",
+        "code_targets": [
+          "vprism/core/services/quality/duplicate_detector.py",
+          "tests/core/services/quality/test_duplicate_detector.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests injecting duplicate rows to ensure counts and statuses align with thresholds.",
+          "Verify no-duplicate scenario yields OK status."
+        ],
+        "dependencies": [
+          "PRD-4-001",
+          "PRD-2-003"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove duplicate detector logic and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-4-005",
+        "title": "Build quality report CLI command",
+        "description": "Add CLI command rendering quality metrics (gap_ratio, duplicate_count) with table and jsonl outputs, honoring threshold metadata and run identifiers.",
+        "source_prd_path": "docs/prd/PRD-4.md",
+        "code_targets": [
+          "vprism/cli/quality.py",
+          "tests/cli/test_quality_report_command.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI test verifying table output includes metric names, values, and statuses.",
+          "Test jsonl output path producing per-row JSON lines."
+        ],
+        "dependencies": [
+          "PRD-4-003",
+          "PRD-4-004",
+          "PRD-5-001",
+          "PRD-5-002",
+          "PRD-5-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove quality CLI command and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-4-006",
+        "title": "Implement threshold evaluation utility for metrics",
+        "description": "Create reusable logic to categorize metric values into OK, WARN, or FAIL based on configured thresholds to ensure consistent status labeling across detectors.",
+        "source_prd_path": "docs/prd/PRD-4.md",
+        "code_targets": [
+          "vprism/core/services/quality/thresholds.py",
+          "tests/core/services/quality/test_thresholds.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests verifying classification boundaries exactly at warn and fail thresholds.",
+          "Test configuration overrides adjusting thresholds dynamically."
+        ],
+        "dependencies": [
+          "PRD-4-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove threshold helper module and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-5-001",
+        "title": "Establish CLI entrypoint with command groups and global options",
+        "description": "Introduce CLI package (e.g., Typer) with data, quality, symbol, and corporate action command groups, handling global options like --format, --output, --log-level, and --no-color.",
+        "source_prd_path": "docs/prd/PRD-5.md",
+        "code_targets": [
+          "vprism/cli/__init__.py",
+          "vprism/cli/main.py",
+          "tests/cli/test_cli_entrypoint.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI smoke tests verifying groups load and --help displays expected commands.",
+          "Test global options altering formatter selection and log level."
+        ],
+        "dependencies": [],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove CLI entrypoint files and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-5-002",
+        "title": "Implement table and JSONL output formatter abstraction",
+        "description": "Create OutputFormatter interface with table and jsonl implementations delivering Rich tables and streaming JSONL output per design requirements.",
+        "source_prd_path": "docs/prd/PRD-5.md",
+        "code_targets": [
+          "vprism/cli/formatters.py",
+          "tests/cli/test_cli_formatters.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Tests verifying table formatter renders expected columns and respects --no-color.",
+          "Tests ensuring jsonl formatter writes line-delimited JSON respecting --output path."
+        ],
+        "dependencies": [
+          "PRD-5-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove formatter implementations and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-5-003",
+        "title": "Implement unified CLI error handling with exit codes",
+        "description": "Add centralized error handler mapping DomainError codes to specified exit codes and formatting error responses with code, message, and context fields.",
+        "source_prd_path": "docs/prd/PRD-5.md",
+        "code_targets": [
+          "vprism/cli/errors.py",
+          "tests/cli/test_cli_error_handling.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI tests verifying different DomainError inputs map to exit codes 10, 20, 30, 40, and 50.",
+          "Ensure error output includes code, message, and context fields."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-7-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove error handling module and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-5-004",
+        "title": "Implement data fetch CLI command",
+        "description": "Wire data fetch command to DataService, accepting asset, market, symbols, date range, timeframe, and format options, streaming results in selected formatter.",
+        "source_prd_path": "docs/prd/PRD-5.md",
+        "code_targets": [
+          "vprism/cli/data.py",
+          "tests/cli/test_data_fetch_command.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI integration test verifying table output for valid fetch and jsonl stream for --format jsonl.",
+          "Negative test with invalid symbol to trigger validation exit code 10."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-5-002",
+          "PRD-5-003",
+          "PRD-2-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove data fetch command module and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-5-005",
+        "title": "Implement symbol resolve CLI command",
+        "description": "Add command invoking SymbolService normalize to resolve symbols for given market and asset, presenting canonical output and diagnostics.",
+        "source_prd_path": "docs/prd/PRD-5.md",
+        "code_targets": [
+          "vprism/cli/symbol.py",
+          "tests/cli/test_symbol_resolve_command.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI test verifying resolved canonical symbol displayed with rule metadata.",
+          "Test unresolved symbol path returns exit code 10 with diagnostics."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-5-002",
+          "PRD-5-003",
+          "PRD-1-001",
+          "PRD-1-002"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove symbol command module and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-5-006",
+        "title": "Support --symbols-from option for data fetch",
+        "description": "Extend data fetch command to load symbols from file (--symbols-from) as part of Should requirements, including validation and error feedback.",
+        "source_prd_path": "docs/prd/PRD-5.md",
+        "code_targets": [
+          "vprism/cli/data.py",
+          "tests/cli/test_symbols_from_file.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Test reading newline-delimited file to supply symbols list.",
+          "Negative test verifying missing file triggers validation exit code."
+        ],
+        "dependencies": [
+          "PRD-5-004"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove file option handling and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-6-001",
+        "title": "Create reconciliation_runs and reconciliation_diffs schemas",
+        "description": "Define DuckDB tables for reconciliation run summaries and per-symbol diffs with specified columns to store sampling results.",
+        "source_prd_path": "docs/prd/PRD-6.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "tests/core/data/test_reconciliation_schema.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "reconciliation_runs",
+              "columns": [
+                "run_id",
+                "market",
+                "start",
+                "end",
+                "source_a",
+                "source_b",
+                "sample_size",
+                "created_at",
+                "pass",
+                "warn",
+                "fail",
+                "p95_bp_diff"
+              ],
+              "primary_key": [
+                "run_id"
+              ]
+            },
+            {
+              "name": "reconciliation_diffs",
+              "columns": [
+                "run_id",
+                "symbol",
+                "date",
+                "close_a",
+                "close_b",
+                "close_bp_diff",
+                "volume_a",
+                "volume_b",
+                "volume_ratio",
+                "status"
+              ],
+              "primary_key": [
+                "run_id",
+                "symbol",
+                "date"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Schema tests verifying columns and constraints for both tables.",
+          "Ensure schema creation integrates with existing migrations."
+        ],
+        "dependencies": [
+          "PRD-0-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove reconciliation table definitions and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-6-002",
+        "title": "Implement ReconciliationService with sampling and classification",
+        "description": "Build ReconciliationService.reconcile to sample symbols, fetch provider data, compute close_bp_diff and volume_ratio, classify PASS, WARN, and FAIL per thresholds, and summarize statistics.",
+        "source_prd_path": "docs/prd/PRD-6.md",
+        "code_targets": [
+          "vprism/core/services/reconciliation.py",
+          "tests/core/services/test_reconciliation_service.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [
+          {
+            "method": "function",
+            "path": "ReconciliationService.reconcile",
+            "req_schema": "{symbols: list[str], market: str, date_range: tuple[date,date]}",
+            "resp_schema": "ReconcileResult",
+            "status_codes": []
+          }
+        ],
+        "test_plan": [
+          "Unit tests for all-pass data, induced WARN and FAIL by bp diff and volume ratio, and missing provider data scenarios.",
+          "Verify sampling strategy draws expected count and classification counts match output."
+        ],
+        "dependencies": [
+          "PRD-6-001",
+          "PRD-2-003",
+          "PRD-1-001"
+        ],
+        "risk_note": "HIGH",
+        "rollback_hint": "Revert ReconciliationService implementation and tests.",
+        "effort": "L",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-6-003",
+        "title": "Persist reconciliation results into DuckDB",
+        "description": "Add logic to store run summaries and detailed diffs into reconciliation tables after each reconcile invocation, including run_id metadata and p95 calculations.",
+        "source_prd_path": "docs/prd/PRD-6.md",
+        "code_targets": [
+          "vprism/core/services/reconciliation.py",
+          "tests/core/services/test_reconciliation_persistence.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Integration test verifying run summary and diff rows persist with correct statuses.",
+          "Ensure subsequent runs create distinct entries keyed by run_id."
+        ],
+        "dependencies": [
+          "PRD-6-002",
+          "PRD-6-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove persistence hooks and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-6-004",
+        "title": "Add reconciliation CLI command",
+        "description": "Provide CLI entry to trigger reconciliation runs with sample size, market, and date range parameters, outputting summary stats and top failing samples.",
+        "source_prd_path": "docs/prd/PRD-6.md",
+        "code_targets": [
+          "vprism/cli/reconciliation.py",
+          "tests/cli/test_reconcile_command.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI test ensuring summary table shows pass, warn, fail counts and p95 diff.",
+          "Test invalid parameter scenarios mapping to appropriate exit codes."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-5-002",
+          "PRD-5-003",
+          "PRD-6-002"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove reconciliation CLI module and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-7-001",
+        "title": "Define DomainError hierarchy and ErrorCode enum",
+        "description": "Introduce ErrorCode enumeration (VALIDATION, ROUTING, PROVIDER, DATA_QUALITY, RECONCILE, SYSTEM) and DomainError base class with layer, retryable flag, and context payloads.",
+        "source_prd_path": "docs/prd/PRD-7.md",
+        "code_targets": [
+          "vprism/core/exceptions/codes.py",
+          "vprism/core/exceptions/domain.py",
+          "tests/core/exceptions/test_domain_error.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests for each error code ensuring properties propagate to DomainError.",
+          "Test serialization of context payload and retryable flag."
+        ],
+        "dependencies": [],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove new error classes and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-7-002",
+        "title": "Implement MetricsCollector and /metrics endpoint",
+        "description": "Create MetricsCollector capturing query latency histogram, failure counts, provider error rate, and expose Prometheus /metrics endpoint via FastAPI integration.",
+        "source_prd_path": "docs/prd/PRD-7.md",
+        "code_targets": [
+          "vprism/core/monitoring/metrics.py",
+          "vprism/web/metrics.py",
+          "tests/web/test_metrics_endpoint.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests verifying metrics collector increments counters and histograms properly.",
+          "Integration test hitting /metrics endpoint and checking expected metric names."
+        ],
+        "dependencies": [
+          "PRD-7-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove metrics collector and web endpoint modules.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-7-003",
+        "title": "Integrate structured JSON logging with trace_id propagation",
+        "description": "Configure logging to emit JSON records including timestamp, level, trace_id (uuid4), error codes, and provider context per observability requirements.",
+        "source_prd_path": "docs/prd/PRD-7.md",
+        "code_targets": [
+          "vprism/core/logging/config.py",
+          "tests/core/logging/test_structured_logging.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests verifying log records include trace_id and structured fields.",
+          "Test that trace_id propagates across multiple log entries within same context."
+        ],
+        "dependencies": [
+          "PRD-7-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Revert logging configuration and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-7-004",
+        "title": "Expose symbol normalization hit-rate metrics",
+        "description": "Connect SymbolService counters to MetricsCollector, publishing vprism_symbol_normalization_total with status labels while respecting cardinality constraints.",
+        "source_prd_path": "docs/prd/PRD-7.md",
+        "code_targets": [
+          "vprism/core/services/symbols.py",
+          "vprism/core/monitoring/metrics.py",
+          "tests/core/services/test_symbol_metrics.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Integration tests ensuring normalization calls increment metrics via collector.",
+          "Verify metrics respect allowed labels (status only) and aggregate correctly."
+        ],
+        "dependencies": [
+          "PRD-1-001",
+          "PRD-7-002"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove metrics hookup and adjust tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-7-005",
+        "title": "Implement slow query logging thresholds",
+        "description": "Add monitoring logic to log slow queries when latency exceeds configured p95 threshold, supporting Should-level observability goals.",
+        "source_prd_path": "docs/prd/PRD-7.md",
+        "code_targets": [
+          "vprism/core/monitoring/performance.py",
+          "tests/core/monitoring/test_slow_query_logging.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests triggering slow query threshold to assert WARN log emission.",
+          "Test normal queries do not produce slow log entries."
+        ],
+        "dependencies": [
+          "PRD-7-003"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove slow query logging hooks and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-8-001",
+        "title": "Implement ShadowController duplicating query paths",
+        "description": "Build ShadowController to execute old and new query paths in parallel, returning old result to users and capturing new result for comparison while respecting sampling policy.",
+        "source_prd_path": "docs/prd/PRD-8.md",
+        "code_targets": [
+          "vprism/core/services/shadow.py",
+          "tests/core/services/test_shadow_controller.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests verifying old path response matches return value while new path runs in background.",
+          "Test sampling configuration limiting execution to subset of symbols."
+        ],
+        "dependencies": [
+          "PRD-5-004"
+        ],
+        "risk_note": "HIGH",
+        "rollback_hint": "Remove ShadowController implementation and tests.",
+        "effort": "L",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-8-002",
+        "title": "Implement DiffEngine computing row and price differences",
+        "description": "Create DiffEngine to compare shadow run results, computing row_diff_pct, price_diff_bp statistics (including p95), and gap_ratio metrics for evaluation.",
+        "source_prd_path": "docs/prd/PRD-8.md",
+        "code_targets": [
+          "vprism/core/services/shadow_diff.py",
+          "tests/core/services/test_shadow_diff_engine.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests injecting synthetic datasets to trigger PASS and FAIL thresholds.",
+          "Verify computed metrics align with specified formulas (row diff, p95 bp, gap ratio)."
+        ],
+        "dependencies": [
+          "PRD-8-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove diff engine logic and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-8-003",
+        "title": "Persist shadow run statistics and manage promote flag",
+        "description": "Add shadow_runs table persistence for aggregated metrics and implement promote and rollback flag handling to swap production paths manually.",
+        "source_prd_path": "docs/prd/PRD-8.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "vprism/core/services/shadow.py",
+          "tests/core/services/test_shadow_persistence.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "shadow_runs",
+              "columns": [
+                "run_id",
+                "start",
+                "end",
+                "asset",
+                "markets",
+                "created_at",
+                "row_diff_pct",
+                "price_diff_bp_p95",
+                "gap_ratio",
+                "status",
+                "sample_percent",
+                "lookback_days",
+                "force_full_run"
+              ],
+              "primary_key": [
+                "run_id"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Integration tests ensuring each shadow run writes summary rows with computed metrics.",
+          "Tests confirming promote and rollback toggles update active path state."
+        ],
+        "dependencies": [
+          "PRD-8-001",
+          "PRD-8-002",
+          "PRD-0-001"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove persistence and promote flag logic.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-8-004",
+        "title": "Implement shadow CLI commands",
+        "description": "Add CLI commands for shadow run, status, promote, and diff inspection, exposing sampling configuration and latest run metrics to operators.",
+        "source_prd_path": "docs/prd/PRD-8.md",
+        "code_targets": [
+          "vprism/cli/shadow.py",
+          "tests/cli/test_shadow_commands.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI tests verifying run command triggers shadow execution and prints summary.",
+          "Tests for promote and rollback commands altering state and reflecting in status output."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-5-002",
+          "PRD-5-003",
+          "PRD-8-001",
+          "PRD-8-002",
+          "PRD-8-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove shadow CLI modules and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-8-005",
+        "title": "Implement auto promote readiness based on consecutive PASS runs",
+        "description": "Track consecutive PASS shadow runs and surface readiness indicator only after configured N successes (default 3) before permitting promote, enforcing safety gate and allowing overrides.",
+        "source_prd_path": "docs/prd/PRD-8.md",
+        "code_targets": [
+          "vprism/core/services/shadow.py",
+          "tests/core/services/test_shadow_promote_guard.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests verifying readiness flips to true only after N consecutive PASS runs with default 3.",
+          "Test that a FAIL resets the pass counter and configuration overrides adjust N."
+        ],
+        "dependencies": [
+          "PRD-8-003",
+          "PRD-8-002"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove pass-counter guard logic and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-9-001",
+        "title": "Create drift_metrics table and models",
+        "description": "Define drift_metrics schema capturing metric name, value, status, window, and run metadata for drift monitoring.",
+        "source_prd_path": "docs/prd/PRD-9.md",
+        "code_targets": [
+          "vprism/core/data/schema.py",
+          "tests/core/data/test_drift_metrics_schema.py"
+        ],
+        "schema_changes": {
+          "tables": [
+            {
+              "name": "drift_metrics",
+              "columns": [
+                "date",
+                "market",
+                "symbol",
+                "metric",
+                "value",
+                "status",
+                "window",
+                "run_id",
+                "created_at"
+              ],
+              "primary_key": [
+                "date",
+                "market",
+                "symbol",
+                "metric",
+                "window",
+                "run_id"
+              ]
+            }
+          ]
+        },
+        "api_changes": [],
+        "test_plan": [
+          "Schema tests ensuring columns and primary key align with specification.",
+          "Verify migrations produce table idempotently."
+        ],
+        "dependencies": [
+          "PRD-0-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove drift_metrics schema definitions and tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-9-002",
+        "title": "Implement DriftService compute with z-score classification",
+        "description": "Build DriftService.compute to gather recent window data, calculate means and standard deviations, compute z-scores for latest values, and classify statuses using thresholds.",
+        "source_prd_path": "docs/prd/PRD-9.md",
+        "code_targets": [
+          "vprism/core/services/drift.py",
+          "tests/core/services/test_drift_service.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [
+          {
+            "method": "function",
+            "path": "DriftService.compute",
+            "req_schema": "{symbol: str, market: str, window: int}",
+            "resp_schema": "DriftResult",
+            "status_codes": []
+          }
+        ],
+        "test_plan": [
+          "Unit tests for OK, WARN, and FAIL scenarios based on z-score thresholds.",
+          "Edge case test with zero standard deviation resulting in z-score 0."
+        ],
+        "dependencies": [
+          "PRD-9-001",
+          "PRD-2-003"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove DriftService implementation and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-9-003",
+        "title": "Add drift report CLI command",
+        "description": "Provide CLI command to invoke DriftService, rendering computed metrics and statuses for specified symbol, market, and window parameters.",
+        "source_prd_path": "docs/prd/PRD-9.md",
+        "code_targets": [
+          "vprism/cli/drift.py",
+          "tests/cli/test_drift_report_command.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "CLI test verifying table output includes z-score metrics and statuses.",
+          "Test jsonl output and exit codes for invalid input cases."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-5-002",
+          "PRD-5-003",
+          "PRD-9-002"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove drift CLI module and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-9-004",
+        "title": "Persist drift metrics with status and run metadata",
+        "description": "Ensure DriftService writes computed metrics into drift_metrics table including run_id, window size, and status for auditability.",
+        "source_prd_path": "docs/prd/PRD-9.md",
+        "code_targets": [
+          "vprism/core/services/drift.py",
+          "tests/core/services/test_drift_persistence.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Integration test verifying drift metrics table receives entries for each computed metric.",
+          "Test repeated runs with same parameters produce distinct run_ids."
+        ],
+        "dependencies": [
+          "PRD-9-002",
+          "PRD-9-001"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove persistence hook and adjust tests.",
+        "effort": "S",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-9-005",
+        "title": "Implement plugin loader framework with entry point discovery",
+        "description": "Create plugin loader scanning vprism.plugins entry points, invoking register(cli_app, services_registry), and skipping conflicts per specification.",
+        "source_prd_path": "docs/prd/PRD-9.md",
+        "code_targets": [
+          "vprism/core/plugins/loader.py",
+          "vprism/cli/main.py",
+          "tests/core/plugins/test_plugin_loader.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Unit tests loading sample plugins verifying commands register and appear in CLI help.",
+          "Ensure conflicting command names are skipped with logged warnings."
+        ],
+        "dependencies": [
+          "PRD-5-001",
+          "PRD-9-002"
+        ],
+        "risk_note": "MEDIUM",
+        "rollback_hint": "Remove plugin loader integration and tests.",
+        "effort": "M",
+        "status": "TODO"
+      },
+      {
+        "id": "PRD-9-006",
+        "title": "Add plugin conflict detection and logging",
+        "description": "Enhance plugin loader to log conflicts, maintain load order visibility, and guard against duplicate registrations as part of conflict management requirements.",
+        "source_prd_path": "docs/prd/PRD-9.md",
+        "code_targets": [
+          "vprism/core/plugins/loader.py",
+          "tests/core/plugins/test_plugin_conflicts.py"
+        ],
+        "schema_changes": {},
+        "api_changes": [],
+        "test_plan": [
+          "Tests injecting conflicting plugins verifying warnings emitted and later plugin skipped.",
+          "Ensure load order logging includes plugin identifiers."
+        ],
+        "dependencies": [
+          "PRD-9-005"
+        ],
+        "risk_note": "LOW",
+        "rollback_hint": "Remove conflict detection enhancements and tests.",
+        "effort": "S",
+        "status": "TODO"
+      }
+    ]
+  },
+  "archive_actions": []
+}

--- a/tests/core/data/ingestion/test_ingest_duplicates.py
+++ b/tests/core/data/ingestion/test_ingest_duplicates.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import duckdb
+
+from vprism.core.data import schema
+from vprism.core.data.ingestion import IngestionConfig, RawRecord, ingest
+
+
+def _make_record(symbol: str, ts: datetime) -> RawRecord:
+    return RawRecord(
+        supplier_symbol=symbol,
+        timestamp=ts,
+        open=10.0,
+        high=11.0,
+        low=9.5,
+        close=10.5,
+        volume=100.0,
+        provider="akshare",
+    )
+
+
+def test_duplicates_are_dropped_when_not_allowed() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    ts = datetime(2024, 1, 1, tzinfo=UTC)
+    records = [_make_record("000001", ts), _make_record("000001", ts)]
+
+    config = IngestionConfig(allow_duplicates=False)
+    result = ingest(conn, records, provider="akshare", market="CN", config=config)
+
+    assert result.written_rows == 1
+    assert result.duplicates_dropped == 1
+    assert any(summary.code == "DUPLICATE_ROW" for summary in result.fail_reasons)
+
+    rows = conn.execute("SELECT COUNT(*) FROM raw_ohlcv").fetchone()[0]
+    assert rows == 1
+
+
+def test_duplicates_inserted_when_allowed() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    ts = datetime(2024, 1, 1, tzinfo=UTC)
+    records = [_make_record("000001", ts), _make_record("000001", ts)]
+
+    config = IngestionConfig(allow_duplicates=True)
+    result = ingest(conn, records, provider="akshare", market="CN", config=config)
+
+    assert result.written_rows == 1
+    assert result.duplicates_dropped == 1
+    assert result.rejected_rows == 0
+    assert any(summary.code == "DUPLICATE_ROW" for summary in result.fail_reasons)
+
+    rows = conn.execute("SELECT COUNT(*) FROM raw_ohlcv").fetchone()[0]
+    assert rows == 1

--- a/tests/core/data/ingestion/test_ingest_reporting.py
+++ b/tests/core/data/ingestion/test_ingest_reporting.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import duckdb
+
+from vprism.core.data import schema
+from vprism.core.data.ingestion import RawRecord, ingest
+
+
+def _record(symbol: str, **overrides: object) -> RawRecord:
+    record = RawRecord(
+        supplier_symbol=symbol,
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        open=10.0,
+        high=11.0,
+        low=9.5,
+        close=10.5,
+        volume=100.0,
+        provider="akshare",
+    )
+    for key, value in overrides.items():
+        setattr(record, key, value)
+    return record
+
+
+def test_fail_reasons_group_multiple_codes() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    records = [
+        _record("000001"),
+        _record("000002", open=None),
+        _record("000003", volume=None),
+        _record("000004", low=12.0),
+    ]
+
+    result = ingest(conn, records, provider="akshare", market="CN")
+
+    fail_counts = {summary.code: summary.count for summary in result.fail_reasons}
+
+    assert fail_counts["MISSING_FIELD"] >= 1
+    assert fail_counts["MISSING_VOLUME_DEFAULTED"] == 1
+    assert fail_counts["LOW_ABOVE_HIGH"] == 1
+    assert result.rejected_rows == 2
+    assert result.written_rows == 2
+
+    rows = conn.execute("SELECT supplier_symbol FROM raw_ohlcv ORDER BY supplier_symbol").fetchall()
+    assert [row[0] for row in rows] == ["000001", "000003"]

--- a/tests/core/data/ingestion/test_ingest_service.py
+++ b/tests/core/data/ingestion/test_ingest_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import duckdb
+import pytest
+
+from vprism.core.data import schema
+from vprism.core.data.ingestion import (
+    IngestionConfig,
+    IngestionConfigError,
+    IngestionResult,
+    RawRecord,
+    ingest,
+)
+
+
+def _make_record(**overrides: object) -> RawRecord:
+    base = RawRecord(
+        supplier_symbol="000001",
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        open=10.0,
+        high=11.0,
+        low=9.5,
+        close=10.5,
+        volume=100.0,
+        provider=None,
+    )
+    for field, value in overrides.items():
+        setattr(base, field, value)
+    return base
+
+
+def test_ingest_persists_valid_rows_and_defaults_missing_volume() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    records = [
+        _make_record(volume=None),
+        _make_record(supplier_symbol="000002", volume=200.0),
+    ]
+
+    result = ingest(conn, records, provider="akshare", market="CN")
+
+    assert isinstance(result, IngestionResult)
+    assert result.written_rows == 2
+    assert result.rejected_rows == 0
+    assert result.duplicates_dropped == 0
+
+    rows = conn.execute("SELECT supplier_symbol, volume, provider, batch_id, ingest_time FROM raw_ohlcv ORDER BY supplier_symbol").fetchall()
+    assert [row[0] for row in rows] == ["000001", "000002"]
+    assert rows[0][1] == -1.0
+    assert rows[0][2] == "akshare"
+    assert rows[0][3] == result.batch_id
+    assert rows[0][4] is not None
+    assert rows[1][1] == 200.0
+    assert any(summary.code == "MISSING_VOLUME_DEFAULTED" for summary in result.fail_reasons)
+
+
+def test_invalid_rows_are_rejected_and_not_persisted() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    valid = _make_record()
+    invalid = _make_record(open=12.0)
+
+    result = ingest(conn, [valid, invalid], provider="akshare", market="CN")
+
+    assert result.written_rows == 1
+    assert result.rejected_rows == 1
+    assert any(summary.code == "OPEN_OUT_OF_RANGE" for summary in result.fail_reasons)
+
+    rows = conn.execute("SELECT COUNT(*) FROM raw_ohlcv").fetchone()[0]
+    assert rows == 1
+
+
+def test_batch_size_limit_violations_raise() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    config = IngestionConfig(max_batch_rows=1)
+
+    records = [_make_record(), _make_record(supplier_symbol="000002")]
+
+    with pytest.raises(IngestionConfigError):
+        ingest(conn, records, provider="akshare", market="CN", config=config)

--- a/tests/core/data/ingestion/test_validator.py
+++ b/tests/core/data/ingestion/test_validator.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from math import inf, nan
+
+from vprism.core.data.ingestion.models import RawRecord
+from vprism.core.data.ingestion.validator import validate_batch
+
+
+def _make_record(**overrides: object) -> RawRecord:
+    base = RawRecord(
+        supplier_symbol="000001",
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        open=10.0,
+        high=11.0,
+        low=9.5,
+        close=10.5,
+        volume=100.0,
+        provider="akshare",
+    )
+    for field, value in overrides.items():
+        setattr(base, field, value)
+    return base
+
+
+def test_validate_batch_accepts_valid_rows() -> None:
+    record = _make_record()
+
+    validated, issues = validate_batch([record], market="CN")
+
+    assert len(validated) == 1
+    assert not issues
+
+
+def test_missing_volume_defaulted_to_minus_one() -> None:
+    record = _make_record(volume=None)
+
+    validated, issues = validate_batch([record], market="CN")
+
+    assert len(validated) == 1
+    assert validated[0].record.volume == -1.0
+    assert any(issue.code == "MISSING_VOLUME_DEFAULTED" and not issue.fatal for issue in issues)
+
+
+def test_missing_numeric_field_is_fatal() -> None:
+    record = _make_record(open=None)
+
+    validated, issues = validate_batch([record], market="CN")
+
+    assert not validated
+    assert any(issue.code == "MISSING_FIELD" and issue.field == "open" for issue in issues)
+
+
+def test_non_finite_values_are_rejected() -> None:
+    record_nan = _make_record(close=nan)
+    record_inf = _make_record(low=-inf)
+
+    validated, issues = validate_batch([record_nan, record_inf], market="CN")
+
+    assert not validated
+    assert sum(1 for issue in issues if issue.code == "NON_FINITE_VALUE") == 2
+
+
+def test_ohlc_relationship_violations_detected() -> None:
+    record = _make_record(low=11.2)
+
+    validated, issues = validate_batch([record], market="CN")
+
+    assert not validated
+    assert any(issue.code == "LOW_ABOVE_HIGH" for issue in issues)
+
+
+def test_negative_volume_rejected() -> None:
+    record = _make_record(volume=-2.0)
+
+    validated, issues = validate_batch([record], market="CN")
+
+    assert not validated
+    assert any(issue.code == "NEGATIVE_VOLUME" for issue in issues)
+
+
+def test_non_monotonic_timestamp_rejected_when_enforced() -> None:
+    first = _make_record(timestamp=datetime(2024, 1, 2, tzinfo=UTC))
+    second = _make_record(timestamp=datetime(2024, 1, 1, tzinfo=UTC))
+
+    validated, issues = validate_batch([first, second], market="CN", enforce_monotonic_ts=True)
+
+    assert len(validated) == 1
+    assert any(issue.code == "NON_MONOTONIC_TIMESTAMP" for issue in issues)
+
+
+def test_non_monotonic_timestamp_allowed_when_not_enforced() -> None:
+    first = _make_record(timestamp=datetime(2024, 1, 2, tzinfo=UTC))
+    second = _make_record(timestamp=datetime(2024, 1, 1, tzinfo=UTC))
+
+    validated, issues = validate_batch([first, second], market="CN", enforce_monotonic_ts=False)
+
+    assert len(validated) == 2
+    assert not any(issue.code == "NON_MONOTONIC_TIMESTAMP" for issue in issues)

--- a/tests/core/data/test_corporate_action_schema.py
+++ b/tests/core/data/test_corporate_action_schema.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import duckdb
+
+from vprism.core.data import schema
+
+
+def test_ensure_corporate_action_tables_creates_expected_columns() -> None:
+    conn = duckdb.connect(database=":memory:")
+
+    schema.ensure_corporate_action_tables(conn)
+
+    corp_columns = [row[1] for row in conn.execute("PRAGMA table_info('corporate_actions')").fetchall()]
+    adj_columns = [row[1] for row in conn.execute("PRAGMA table_info('adjustments')").fetchall()]
+    corp_pk = [row[1] for row in conn.execute("PRAGMA table_info('corporate_actions')").fetchall() if row[5] > 0]
+    adj_pk = [row[1] for row in conn.execute("PRAGMA table_info('adjustments')").fetchall() if row[5] > 0]
+
+    assert corp_columns == [
+        "market",
+        "supplier_symbol",
+        "event_type",
+        "effective_date",
+        "dividend_cash",
+        "split_ratio",
+        "raw_payload",
+        "source",
+        "batch_id",
+        "ingest_time",
+    ]
+    assert adj_columns == [
+        "market",
+        "supplier_symbol",
+        "date",
+        "adj_factor_qfq",
+        "adj_factor_hfq",
+        "version",
+        "build_time",
+        "source_events_hash",
+    ]
+    assert corp_pk == [
+        "market",
+        "supplier_symbol",
+        "event_type",
+        "effective_date",
+        "batch_id",
+    ]
+    assert adj_pk == ["market", "supplier_symbol", "date", "version"]
+
+
+def test_create_corporate_action_ddl_exposes_statements() -> None:
+    ddls = list(schema.create_corporate_action_ddl())
+
+    assert any("CREATE TABLE IF NOT EXISTS corporate_actions" in ddl for ddl in ddls)
+    assert any("CREATE TABLE IF NOT EXISTS adjustments" in ddl for ddl in ddls)

--- a/tests/core/data/test_duckdb_factory.py
+++ b/tests/core/data/test_duckdb_factory.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from vprism.core.data.storage.duckdb_factory import (
+    DuckDBFactoryConfig,
+    VPrismDuckDBFactory,
+)
+
+
+def test_connection_factory_context_yields_and_closes_connection() -> None:
+    factory = VPrismDuckDBFactory()
+
+    with factory.connection() as conn:
+        result = conn.execute("SELECT 1").fetchone()[0]
+        assert result == 1
+
+    with pytest.raises(duckdb.Error):
+        conn.execute("SELECT 1")
+
+
+def test_connection_factory_applies_pragmas() -> None:
+    factory = VPrismDuckDBFactory(
+        DuckDBFactoryConfig(pragmas={"threads": 3})
+    )
+
+    with factory.connection() as conn:
+        threads = conn.execute("SELECT current_setting('threads')").fetchone()[0]
+
+    assert threads == 3
+
+
+def test_create_connection_returns_active_connection() -> None:
+    factory = VPrismDuckDBFactory()
+
+    conn = factory.create_connection()
+    try:
+        assert conn.execute("SELECT 2").fetchone()[0] == 2
+    finally:
+        conn.close()

--- a/tests/core/data/test_raw_schema.py
+++ b/tests/core/data/test_raw_schema.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import duckdb
+
+from datetime import datetime
+
+from vprism.core.data import schema
+from vprism.core.data.ingestion.models import RawRecord
+
+
+def test_raw_ohlcv_table_has_expected_columns_and_constraints() -> None:
+    conn = duckdb.connect(database=":memory:")
+
+    schema.RAW_OHLCV_TABLE.ensure(conn)
+
+    column_info = conn.execute("PRAGMA table_info('raw_ohlcv')").fetchall()
+    column_names = [row[1] for row in column_info]
+    not_null_columns = {row[1] for row in column_info if row[3] == 1}
+    primary_key_columns = {row[1] for row in column_info if row[5] > 0}
+
+    assert column_names == [
+        "supplier_symbol",
+        "market",
+        "ts",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "provider",
+        "batch_id",
+        "ingest_time",
+    ]
+    assert not_null_columns == {
+        "supplier_symbol",
+        "market",
+        "ts",
+        "provider",
+        "batch_id",
+        "ingest_time",
+    }
+    assert primary_key_columns == {
+        "supplier_symbol",
+        "market",
+        "ts",
+        "batch_id",
+    }
+
+
+def test_raw_ohlcv_table_create_ddl_includes_primary_key() -> None:
+    ddl = schema.RAW_OHLCV_TABLE.create_ddl()
+
+    assert "CREATE TABLE IF NOT EXISTS raw_ohlcv" in ddl
+    assert "PRIMARY KEY (supplier_symbol, market, ts, batch_id)" in ddl
+
+
+def test_raw_record_defaults_allow_missing_optional_fields() -> None:
+    record = RawRecord(
+        supplier_symbol="000001",
+        timestamp=datetime(2024, 1, 1, 0, 0, 0),
+        open=10.0,
+        high=11.0,
+        low=9.5,
+        close=10.5,
+    )
+
+    assert record.volume is None
+    assert record.provider is None

--- a/tests/core/data/test_schema_module.py
+++ b/tests/core/data/test_schema_module.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import duckdb
+
+from vprism.core.data import schema
+
+
+def test_create_baseline_tables_contains_expected_columns() -> None:
+    conn = duckdb.connect(database=":memory:")
+
+    schema.ensure_baseline_tables(conn)
+
+    raw_columns = [row[1] for row in conn.execute("PRAGMA table_info('raw_schema')").fetchall()]
+    normalization_columns = [row[1] for row in conn.execute("PRAGMA table_info('normalization_schema')").fetchall()]
+
+    assert raw_columns == [
+        "supplier_symbol",
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "provider",
+    ]
+
+    assert normalization_columns == [
+        "supplier_symbol",
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "provider",
+        "market",
+        "tz_offset",
+        "currency",
+        "c_symbol",
+    ]
+
+
+def test_create_baseline_ddl_exposes_statements() -> None:
+    ddls = list(schema.create_baseline_ddl())
+
+    assert any("CREATE TABLE IF NOT EXISTS raw_schema" in ddl for ddl in ddls)
+    assert any("CREATE TABLE IF NOT EXISTS normalization_schema" in ddl for ddl in ddls)

--- a/tests/core/data/test_stub_provider_ingestion.py
+++ b/tests/core/data/test_stub_provider_ingestion.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import duckdb
+import pytest
+
+from vprism.core.data import schema
+from vprism.core.data.providers.stub_provider import StubProviderRow, VPrismStubProvider
+from vprism.core.exceptions.base import DataValidationError
+
+
+def test_stub_provider_inserts_valid_rows() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.ensure_baseline_tables(conn)
+    provider = VPrismStubProvider(conn)
+
+    rows = [
+        StubProviderRow(
+            supplier_symbol="000001.SZ",
+            timestamp=datetime(2024, 1, 1, 0, 0, 0),
+            open=10.0,
+            high=10.5,
+            low=9.8,
+            close=10.2,
+            volume=1000.0,
+            provider="stub",
+        )
+    ]
+
+    provider.ingest_rows(rows)
+
+    stored_rows = conn.execute(
+        "SELECT supplier_symbol, close, volume FROM raw_schema"
+    ).fetchall()
+
+    assert stored_rows == [("000001.SZ", 10.2, 1000.0)]
+
+
+def test_stub_provider_rejects_missing_required_fields() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.ensure_baseline_tables(conn)
+    provider = VPrismStubProvider(conn)
+
+    with pytest.raises(DataValidationError) as exc_info:
+        provider.ingest_rows(
+            [
+                {
+                    "supplier_symbol": "000001.SZ",
+                    "open": 10.0,
+                }
+            ]
+        )
+
+    assert exc_info.value.validation_errors == {
+        "rows": [
+            {
+                "index": 0,
+                "missing_fields": ["timestamp"],
+            }
+        ]
+    }
+    assert conn.execute("SELECT COUNT(*) FROM raw_schema").fetchone()[0] == 0

--- a/tests/core/services/test_adjustment_engine.py
+++ b/tests/core/services/test_adjustment_engine.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from vprism.core.exceptions.base import AdjustmentInputError
+from vprism.core.models.base import DataPoint
+from vprism.core.models.corporate_actions import (
+    CorporateActionSet,
+    DividendEvent,
+    SplitEvent,
+)
+from vprism.core.models.market import MarketType
+from vprism.core.models.query import Adjustment
+from vprism.core.services.adjustment_engine import AdjustmentEngine
+
+
+def _point(day: date, close: str) -> DataPoint:
+    return DataPoint(
+        symbol="000001",
+        market=MarketType.CN,
+        timestamp=datetime.combine(day, datetime.min.time()),
+        close_price=Decimal(close),
+        provider="test",
+    )
+
+
+def _loader(points: list[DataPoint]):
+    def _inner(symbol: str, market: MarketType, start: date, end: date) -> list[DataPoint]:
+        return list(points)
+
+    return _inner
+
+
+def _actions(dividends: list[DividendEvent], splits: list[SplitEvent]):
+    action_set = CorporateActionSet(dividends=tuple(dividends), splits=tuple(splits))
+
+    def _inner(symbol: str, market: MarketType, start: date, end: date) -> CorporateActionSet:
+        return action_set
+
+    return _inner
+
+
+def test_compute_without_events_returns_identity() -> None:
+    points = [_point(date(2024, 1, 1), "10"), _point(date(2024, 1, 2), "11"), _point(date(2024, 1, 3), "12")]
+    engine = AdjustmentEngine(_loader(points), _actions([], []))
+
+    result = engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 3), Adjustment.NONE)
+
+    assert [row.close_qfq for row in result.rows] == [Decimal("10"), Decimal("11"), Decimal("12")]
+    assert [row.close_hfq for row in result.rows] == [Decimal("10"), Decimal("11"), Decimal("12")]
+    assert result.source_events_hash == hashlib.sha256(b"").hexdigest()
+    assert result.version == f"1:{result.source_events_hash[:12]}"
+    assert result.action_gap_flag is False
+
+
+def test_compute_handles_dividend_and_split_sequence() -> None:
+    points = [
+        _point(date(2024, 1, 1), "100"),
+        _point(date(2024, 1, 2), "98"),
+        _point(date(2024, 1, 3), "49"),
+    ]
+    dividends = [
+        DividendEvent(
+            symbol="000001",
+            market=MarketType.CN,
+            ex_date=date(2024, 1, 2),
+            pay_date=None,
+            cash_amount=Decimal("2"),
+        )
+    ]
+    splits = [
+        SplitEvent(
+            symbol="000001",
+            market=MarketType.CN,
+            ex_date=date(2024, 1, 3),
+            numerator=2,
+            denominator=1,
+        )
+    ]
+    engine = AdjustmentEngine(_loader(points), _actions(dividends, splits))
+
+    result = engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 3), Adjustment.FORWARD)
+
+    factors = [row.adj_factor_hfq.quantize(Decimal("0.0001")) for row in result.rows]
+    assert factors == [Decimal("1.0000"), Decimal("1.0204"), Decimal("2.0408")]
+
+    q_factors = [row.adj_factor_qfq.quantize(Decimal("0.0001")) for row in result.rows]
+    assert q_factors == [Decimal("0.4900"), Decimal("0.5000"), Decimal("1.0000")]
+
+    close_hfq = [row.close_hfq.quantize(Decimal("0.0001")) for row in result.rows if row.close_hfq is not None]
+    close_qfq = [row.close_qfq.quantize(Decimal("0.0001")) for row in result.rows if row.close_qfq is not None]
+
+    assert close_hfq == [Decimal("100.0000"), Decimal("100.0000"), Decimal("100.0000")]
+    assert close_qfq == [Decimal("49.0000"), Decimal("49.0000"), Decimal("49.0000")]
+    assert result.action_gap_flag is False
+
+
+def test_compute_raises_without_prices() -> None:
+    engine = AdjustmentEngine(_loader([]), _actions([], []))
+
+    with pytest.raises(AdjustmentInputError):
+        engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 2), Adjustment.NONE)
+
+
+def test_gap_flag_set_when_missing_previous_close() -> None:
+    points = [_point(date(2024, 1, 2), "10")]
+    dividends = [
+        DividendEvent(
+            symbol="000001",
+            market=MarketType.CN,
+            ex_date=date(2024, 1, 2),
+            cash_amount=Decimal("1"),
+        )
+    ]
+    engine = AdjustmentEngine(_loader(points), _actions(dividends, []))
+
+    result = engine.compute("000001", MarketType.CN, date(2024, 1, 2), date(2024, 1, 2), Adjustment.NONE)
+
+    assert result.action_gap_flag is True
+    assert result.rows[0].adj_factor_hfq == Decimal("1")
+
+
+def test_version_hash_stable_for_identical_inputs() -> None:
+    points = [_point(date(2024, 1, 1), "10"), _point(date(2024, 1, 2), "11")]
+    dividends = [
+        DividendEvent(
+            symbol="000001",
+            market=MarketType.CN,
+            ex_date=date(2024, 1, 2),
+            cash_amount=Decimal("0.5"),
+        )
+    ]
+    engine = AdjustmentEngine(_loader(points), _actions(dividends, []))
+
+    first = engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 2), Adjustment.BACKWARD)
+    second = engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 2), Adjustment.BACKWARD)
+
+    assert first.source_events_hash == second.source_events_hash
+    assert first.version == second.version
+    assert first.mode == Adjustment.BACKWARD

--- a/tests/core/services/test_symbol_batch.py
+++ b/tests/core/services/test_symbol_batch.py
@@ -1,0 +1,68 @@
+import pytest
+
+from vprism.core.exceptions.base import UnresolvedSymbolError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.services.symbols import SymbolService
+
+
+@pytest.mark.parametrize(
+    "raw_symbols",
+    [
+        ["000001.SZ", "600519.SH", "@@INVALID@@"],
+        [" 000001.SZ ", "600519.SH", " @@INVALID@@ "],
+    ],
+)
+def test_normalize_batch_mixed_results(raw_symbols: list[str]) -> None:
+    service = SymbolService()
+
+    result = service.normalize_batch(raw_symbols, MarketType.CN, AssetType.STOCK)
+
+    assert len(result.items) == len(raw_symbols)
+    assert [item.status for item in result.items] == ["resolved", "resolved", "unresolved"]
+
+    resolved_canonicals = [item.canonical for item in result.items if item.status == "resolved"]
+    assert len(resolved_canonicals) == 2
+    assert all(canonical is not None for canonical in resolved_canonicals)
+    canonical_values = {canonical.canonical for canonical in resolved_canonicals if canonical}
+    assert canonical_values == {"CN:STOCK:SZ000001", "CN:STOCK:SH600519"}
+
+    assert len(result.successes) == 2
+    assert {symbol.raw_symbol for symbol in result.successes} == {"000001.SZ", "600519.SH"}
+
+    assert len(result.failures) == 1
+    failure = result.failures[0]
+    assert isinstance(failure, UnresolvedSymbolError)
+    assert failure.details["raw_symbol"] == "@@INVALID@@"
+
+    unresolved_items = [item for item in result.items if item.status == "unresolved"]
+    assert len(unresolved_items) == 1
+    assert unresolved_items[0].error is failure
+
+
+def test_normalize_batch_updates_metrics_and_cache() -> None:
+    service = SymbolService()
+
+    first_batch = service.normalize_batch(
+        ["000001.SZ", "000001.SZ", "@@INVALID@@"],
+        MarketType.CN,
+        AssetType.STOCK,
+    )
+
+    metrics = service.get_metrics()
+    assert metrics["total_requests"] == 3
+    assert metrics["cache_misses"] == 2
+    assert metrics["cache_hits"] == 1
+    assert metrics["unresolved_count"] == 1
+
+    assert len(first_batch.successes) == 2
+    assert len(first_batch.failures) == 1
+
+    second_batch = service.normalize_batch(["000001.SZ"], MarketType.CN, AssetType.STOCK)
+    assert len(second_batch.failures) == 0
+    assert len(second_batch.successes) == 1
+
+    metrics_after_second = service.get_metrics()
+    assert metrics_after_second["total_requests"] == 4
+    assert metrics_after_second["cache_hits"] == 2
+    assert metrics_after_second["cache_misses"] == 2
+    assert metrics_after_second["unresolved_count"] == 1

--- a/tests/core/services/test_symbol_metrics.py
+++ b/tests/core/services/test_symbol_metrics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from vprism.core.exceptions.base import UnresolvedSymbolError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.models.symbols import SymbolRule
+from vprism.core.services.symbols import SymbolService
+
+
+@pytest.fixture()
+def metrics_service() -> SymbolService:
+    numeric_rule = SymbolRule(
+        id="cn_numeric",
+        priority=10,
+        pattern=re.compile(r"^(?P<code>\d{6})$"),
+        transform=lambda raw, match: match.group("code"),
+        market_scope=frozenset({MarketType.CN}),
+        asset_scope=frozenset({AssetType.STOCK}),
+    )
+    return SymbolService(rules=[numeric_rule])
+
+
+def test_metrics_capture_cache_behavior(metrics_service: SymbolService) -> None:
+    service = metrics_service
+
+    service.normalize("600010", MarketType.CN, AssetType.STOCK)
+    first_metrics = service.get_metrics()
+    assert first_metrics["total_requests"] == 1
+    assert first_metrics["cache_hits"] == 0
+    assert first_metrics["cache_misses"] == 1
+    assert first_metrics["hit_rate"] == 0.0
+
+    service.normalize("600010", MarketType.CN, AssetType.STOCK)
+    second_metrics = service.get_metrics()
+    assert second_metrics["total_requests"] == 2
+    assert second_metrics["cache_hits"] == 1
+    assert second_metrics["hit_rate"] == 0.5
+    assert second_metrics["rule_usage"]["cn_numeric"] == 1
+
+
+def test_metrics_track_unresolved(metrics_service: SymbolService) -> None:
+    service = metrics_service
+
+    with pytest.raises(UnresolvedSymbolError):
+        service.normalize("BAD", MarketType.CN, AssetType.STOCK)
+
+    metrics = service.get_metrics()
+    assert metrics["unresolved_count"] == 1
+    assert metrics["total_requests"] == 1

--- a/tests/core/services/test_symbol_persistence.py
+++ b/tests/core/services/test_symbol_persistence.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from vprism.core.data.storage.duckdb_factory import VPrismDuckDBFactory
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.services.symbols import SymbolService
+
+
+def _fetch_symbol_map_rows(conn) -> list[tuple]:
+    return conn.execute(
+        """
+        SELECT c_symbol, raw_symbol, market, asset_type, provider_hint, rule_id, created_at
+        FROM symbol_map
+        ORDER BY raw_symbol
+        """
+    ).fetchall()
+
+
+@pytest.fixture()
+def duckdb_conn():
+    factory = VPrismDuckDBFactory()
+    with factory.connection() as conn:
+        yield conn
+
+
+def test_persistence_inserts_row_on_first_normalization(duckdb_conn) -> None:
+    service = SymbolService(persistence_conn=duckdb_conn)
+
+    result = service.normalize("600000.SS", MarketType.CN, AssetType.STOCK, provider_hint="yfinance")
+
+    rows = _fetch_symbol_map_rows(duckdb_conn)
+    assert len(rows) == 1
+    (c_symbol, raw_symbol, market, asset_type, provider_hint, rule_id, created_at) = rows[0]
+    assert c_symbol == result.canonical
+    assert raw_symbol == "600000.SS"
+    assert market == MarketType.CN.value
+    assert asset_type == AssetType.STOCK.value
+    assert provider_hint == "yfinance"
+    assert rule_id == result.rule_id
+    assert isinstance(created_at, datetime)
+
+
+def test_persistence_skips_duplicates_with_insert_or_ignore(duckdb_conn) -> None:
+    primary_service = SymbolService(persistence_conn=duckdb_conn)
+    primary_service.normalize("600000.SS", MarketType.CN, AssetType.STOCK, provider_hint="yfinance")
+
+    secondary_service = SymbolService(persistence_conn=duckdb_conn)
+    secondary_service.normalize("600000.SS", MarketType.CN, AssetType.STOCK, provider_hint="akshare")
+
+    rows = _fetch_symbol_map_rows(duckdb_conn)
+    assert len(rows) == 1
+    (_, _, _, _, provider_hint, _, _) = rows[0]
+    assert provider_hint == "yfinance"
+
+
+def test_persistence_allows_null_provider_hint(duckdb_conn) -> None:
+    service = SymbolService(persistence_conn=duckdb_conn)
+
+    service.normalize("000001.SZ", MarketType.CN, AssetType.STOCK)
+
+    rows = _fetch_symbol_map_rows(duckdb_conn)
+    assert len(rows) == 1
+    (_, raw_symbol, _, _, provider_hint, _, _) = rows[0]
+    assert raw_symbol == "000001.SZ"
+    assert provider_hint is None

--- a/tests/core/services/test_symbol_reload.py
+++ b/tests/core/services/test_symbol_reload.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.models.symbols import SymbolRule
+from vprism.core.services.symbols import SymbolService
+
+
+def _rule_with_prefix(prefix: str, priority: int) -> SymbolRule:
+    return SymbolRule(
+        id=f"rule_{prefix.lower()}",
+        priority=priority,
+        pattern=re.compile(r"^(?P<code>\d{6})$"),
+        transform=lambda raw, match, p=prefix: f"{p}{match.group('code')}",
+        market_scope=frozenset({MarketType.CN}),
+        asset_scope=frozenset({AssetType.STOCK}),
+    )
+
+
+def test_reload_replaces_rules_and_clears_cache() -> None:
+    original_rule = _rule_with_prefix("OLD", 10)
+    service = SymbolService(rules=[original_rule])
+
+    first = service.normalize("600500", MarketType.CN, AssetType.STOCK)
+    assert first.canonical == "CN:STOCK:OLD600500"
+
+    metrics_before = service.get_metrics()
+    assert metrics_before["cache_misses"] == 1
+
+    new_rule = _rule_with_prefix("NEW", 5)
+    service.reload([new_rule])
+
+    second = service.normalize("600500", MarketType.CN, AssetType.STOCK)
+    assert second.canonical == "CN:STOCK:NEW600500"
+
+    metrics_after = service.get_metrics()
+    assert metrics_after["cache_hits"] == 0
+    assert metrics_after["cache_misses"] == 2
+    assert metrics_after["rule_usage"]["rule_new"] == 1
+    assert "rule_old" not in metrics_after["rule_usage"]
+
+
+def test_reload_rejects_empty_rule_set() -> None:
+    service = SymbolService(rules=[_rule_with_prefix("A", 1)])
+
+    with pytest.raises(ValueError):
+        service.reload([])
+
+    with pytest.raises(TypeError):
+        service.reload(["not-a-rule"])  # type: ignore[arg-type]

--- a/tests/core/services/test_symbol_rule_loader.py
+++ b/tests/core/services/test_symbol_rule_loader.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from vprism.core.exceptions.base import DataValidationError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.services.symbol_rule_loader import (
+    load_symbol_rules,
+    load_symbol_rules_from_mapping,
+)
+from vprism.core.services.symbols import SymbolService
+
+
+def test_load_symbol_rules_from_yaml_file(tmp_path: Path) -> None:
+    config_text = dedent(
+        r"""
+        rules:
+          - id: cn_stock_suffix
+            priority: 10
+            pattern: '^(?P<code>\d{6})\.(?P<suffix>[A-Za-z]{2})$'
+            flags: ["IGNORECASE"]
+            transform:
+              type: map_template
+              group: suffix
+              mapping:
+                SS: SH
+                SH: SH
+                SZ: SZ
+              template: "{mapped}{code}"
+            market_scope: ["CN"]
+            asset_scope: ["stock"]
+          - id: cn_stock_numeric
+            priority: 20
+            pattern: '^(?P<code>\d{6})$'
+            transform:
+              type: template
+              template: "{code}"
+            market_scope: ["CN"]
+            asset_scope: ["stock"]
+        """
+    )
+    config_path = tmp_path / "rules.yaml"
+    config_path.write_text(config_text, encoding="utf-8")
+
+    rules = load_symbol_rules(config_path)
+    service = SymbolService(rules=rules)
+
+    assert service.normalize("600000.SS", MarketType.CN, AssetType.STOCK).canonical == "CN:STOCK:SH600000"
+    assert service.normalize("000001", MarketType.CN, AssetType.STOCK).canonical == "CN:STOCK:000001"
+
+
+def test_load_symbol_rules_from_mapping_rejects_invalid_definition() -> None:
+    config = {
+        "rules": [
+            {
+                "priority": "high",  # invalid priority type
+                "pattern": "^.+$",
+                "transform": {"type": "template", "template": "{match}"},
+            }
+        ]
+    }
+
+    with pytest.raises(DataValidationError):
+        load_symbol_rules_from_mapping(config)
+
+
+def test_load_symbol_rules_from_file_rejects_unknown_suffix(tmp_path: Path) -> None:
+    config = {"rules": []}
+    path = tmp_path / "rules.toml"
+    path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(DataValidationError):
+        load_symbol_rules(path)

--- a/tests/core/services/test_symbol_rules.py
+++ b/tests/core/services/test_symbol_rules.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from vprism.core.exceptions.base import UnresolvedSymbolError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.services.symbols import SymbolService
+
+
+@pytest.mark.parametrize(
+    "raw_symbol, asset_type, expected",
+    [
+        ("600000.SS", AssetType.STOCK, "CN:STOCK:SH600000"),
+        ("sz000002", AssetType.STOCK, "CN:STOCK:SZ000002"),
+        ("000001", AssetType.STOCK, "CN:STOCK:000001"),
+        ("159915.SZ", AssetType.FUND, "CN:FUND:SZ159915"),
+        ("of110022", AssetType.FUND, "CN:FUND:OF110022"),
+        ("110022", AssetType.FUND, "CN:FUND:110022"),
+        ("000300.SH", AssetType.INDEX, "CN:INDEX:SH000300"),
+        ("sz399001", AssetType.INDEX, "CN:INDEX:SZ399001"),
+    ],
+)
+def test_default_rules_cover_cn_assets(
+    raw_symbol: str, asset_type: AssetType, expected: str
+) -> None:
+    service = SymbolService()
+
+    result = service.normalize(raw_symbol, MarketType.CN, asset_type)
+
+    assert result.canonical == expected
+
+
+def test_default_rules_support_generic_uppercase() -> None:
+    service = SymbolService()
+
+    result = service.normalize("aapl", MarketType.US, AssetType.STOCK)
+
+    assert result.canonical == "US:STOCK:AAPL"
+
+
+def test_default_rules_raise_for_unknown_pattern() -> None:
+    service = SymbolService()
+
+    with pytest.raises(UnresolvedSymbolError):
+        service.normalize("??symbol??", MarketType.CN, AssetType.STOCK)

--- a/tests/core/services/test_symbol_service.py
+++ b/tests/core/services/test_symbol_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from vprism.core.exceptions.base import UnresolvedSymbolError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.models.symbols import SymbolRule
+from vprism.core.services.symbols import SymbolService
+
+
+@pytest.fixture()
+def sample_rules() -> list[SymbolRule]:
+    return [
+        SymbolRule(
+            id="cn_stock_numeric",
+            priority=10,
+            pattern=re.compile(r"^(?P<code>\d{6})$"),
+            transform=lambda raw, match: match.group("code"),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.STOCK}),
+        ),
+        SymbolRule(
+            id="fallback_upper",
+            priority=20,
+            pattern=re.compile(r"^(?P<token>[A-Z]{1,5})$", re.IGNORECASE),
+            transform=lambda raw, match: match.group("token").upper(),
+            market_scope=frozenset(),
+            asset_scope=frozenset(),
+        ),
+    ]
+
+
+def test_normalize_returns_canonical_symbol(sample_rules: list[SymbolRule]) -> None:
+    service = SymbolService(rules=sample_rules)
+
+    result = service.normalize("600000", MarketType.CN, AssetType.STOCK)
+
+    assert result.canonical == "CN:STOCK:600000"
+    assert result.rule_id == "cn_stock_numeric"
+
+
+def test_normalize_uses_cache_metrics(sample_rules: list[SymbolRule]) -> None:
+    service = SymbolService(rules=sample_rules)
+
+    first = service.normalize("600000", MarketType.CN, AssetType.STOCK)
+    metrics_after_first = service.get_metrics()
+    assert metrics_after_first["cache_hits"] == 0
+    assert metrics_after_first["cache_misses"] == 1
+
+    second = service.normalize("600000", MarketType.CN, AssetType.STOCK)
+    metrics_after_second = service.get_metrics()
+    assert second is first
+    assert metrics_after_second["cache_hits"] == 1
+    assert metrics_after_second["total_requests"] == 2
+
+
+def test_normalize_raises_unresolved_with_diagnostics(sample_rules: list[SymbolRule]) -> None:
+    service = SymbolService(rules=sample_rules)
+
+    with pytest.raises(UnresolvedSymbolError) as exc_info:
+        service.normalize("@@INVALID@@", MarketType.CN, AssetType.STOCK)
+
+    error = exc_info.value
+    assert error.error_code == "SYMBOL_UNRESOLVED"
+    assert error.details["raw_symbol"] == "@@INVALID@@"
+    assert error.details["market"] == MarketType.CN.value
+    assert error.details["asset_type"] == AssetType.STOCK.value
+
+
+def test_rule_priority_short_circuits(sample_rules: list[SymbolRule]) -> None:
+    high_priority = SymbolRule(
+        id="high_priority",
+        priority=0,
+        pattern=re.compile(r"^(?P<code>\d{6})$"),
+        transform=lambda raw, match: f"A{match.group('code')}",
+        market_scope=frozenset({MarketType.CN}),
+        asset_scope=frozenset({AssetType.STOCK}),
+    )
+    rules = [sample_rules[1], sample_rules[0], high_priority]
+    service = SymbolService(rules=rules)
+
+    result = service.normalize("600001", MarketType.CN, AssetType.STOCK)
+
+    assert result.canonical == "CN:STOCK:A600001"
+    assert result.rule_id == "high_priority"
+    metrics = service.get_metrics()
+    assert metrics["rule_usage"]["high_priority"] == 1

--- a/tests/core/validation/test_schema_assertions.py
+++ b/tests/core/validation/test_schema_assertions.py
@@ -1,0 +1,124 @@
+"""Tests for DuckDB schema assertion helpers."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from vprism.core.data.schema import (
+    NORMALIZATION_BASE_TABLE,
+    RAW_BASE_TABLE,
+    ensure_baseline_tables,
+)
+from vprism.core.exceptions.base import DataValidationError
+from vprism.core.validation.schema_assertions import (
+    assert_baseline_tables,
+    assert_table_matches_schema,
+)
+
+
+@pytest.fixture()
+def duckdb_conn() -> duckdb.DuckDBPyConnection:
+    """Provide an in-memory DuckDB connection for tests."""
+
+    connection = duckdb.connect(database=":memory:")
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def test_assert_table_matches_schema_success(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
+    """The helper passes when table definitions match exactly."""
+
+    ensure_baseline_tables(duckdb_conn)
+
+    # Should not raise for either baseline table.
+    assert_table_matches_schema(duckdb_conn, RAW_BASE_TABLE)
+    assert_table_matches_schema(duckdb_conn, NORMALIZATION_BASE_TABLE)
+
+
+def test_assert_table_matches_schema_missing_column(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
+    """Missing required columns trigger validation errors."""
+
+    duckdb_conn.execute(
+        """
+        CREATE TABLE raw_schema (
+            supplier_symbol VARCHAR NOT NULL,
+            timestamp TIMESTAMP NOT NULL,
+            open DOUBLE,
+            high DOUBLE,
+            low DOUBLE,
+            close DOUBLE,
+            provider VARCHAR
+        )
+        """
+    )
+
+    with pytest.raises(DataValidationError) as exc_info:
+        assert_table_matches_schema(duckdb_conn, RAW_BASE_TABLE)
+
+    errors = exc_info.value.validation_errors
+    assert "volume" in errors["missing_columns"]
+
+
+def test_assert_table_matches_schema_type_mismatch(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
+    """Type mismatches are surfaced with detailed diagnostics."""
+
+    duckdb_conn.execute(
+        """
+        CREATE TABLE raw_schema (
+            supplier_symbol VARCHAR NOT NULL,
+            timestamp TIMESTAMP NOT NULL,
+            open VARCHAR,
+            high DOUBLE,
+            low DOUBLE,
+            close DOUBLE,
+            volume DOUBLE,
+            provider VARCHAR
+        )
+        """
+    )
+
+    with pytest.raises(DataValidationError) as exc_info:
+        assert_table_matches_schema(duckdb_conn, RAW_BASE_TABLE)
+
+    type_mismatches = exc_info.value.validation_errors["type_mismatches"]
+    mismatch = type_mismatches["open"]
+    assert mismatch["expected"] == "DOUBLE"
+    assert mismatch["actual"] == "VARCHAR"
+
+
+def test_assert_table_matches_schema_not_null_mismatch(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
+    """Missing NOT NULL constraints are reported."""
+
+    duckdb_conn.execute(
+        """
+        CREATE TABLE raw_schema (
+            supplier_symbol VARCHAR,
+            timestamp TIMESTAMP,
+            open DOUBLE,
+            high DOUBLE,
+            low DOUBLE,
+            close DOUBLE,
+            volume DOUBLE,
+            provider VARCHAR
+        )
+        """
+    )
+
+    with pytest.raises(DataValidationError) as exc_info:
+        assert_table_matches_schema(duckdb_conn, RAW_BASE_TABLE)
+
+    constraint_mismatches = exc_info.value.validation_errors["constraint_mismatches"]
+    assert constraint_mismatches["supplier_symbol"]["expected_not_null"] is True
+    assert constraint_mismatches["supplier_symbol"]["actual_not_null"] is False
+    assert constraint_mismatches["timestamp"]["expected_not_null"] is True
+
+
+def test_assert_baseline_tables_success(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
+    """Aggregate assertion validates all baseline schemas."""
+
+    ensure_baseline_tables(duckdb_conn)
+
+    assert_baseline_tables(duckdb_conn)

--- a/vprism/core/data/__init__.py
+++ b/vprism/core/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data layer primitives for vprism."""
+
+from vprism.core.data import schema
+
+__all__ = ["schema"]

--- a/vprism/core/data/ingestion/__init__.py
+++ b/vprism/core/data/ingestion/__init__.py
@@ -1,1 +1,18 @@
+"""Raw data ingestion models and helpers."""
+
 from __future__ import annotations
+
+from vprism.core.data.ingestion.config import IngestionConfig, IngestionConfigError
+from vprism.core.data.ingestion.models import RawRecord
+from vprism.core.data.ingestion.service import FailureSummary, IngestionResult, ingest
+from vprism.core.data.ingestion.validator import ValidationIssue
+
+__all__ = [
+    "FailureSummary",
+    "IngestionConfig",
+    "IngestionConfigError",
+    "IngestionResult",
+    "RawRecord",
+    "ValidationIssue",
+    "ingest",
+]

--- a/vprism/core/data/ingestion/config.py
+++ b/vprism/core/data/ingestion/config.py
@@ -1,0 +1,33 @@
+"""Configuration primitives for the ingestion service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vprism.core.exceptions.base import VPrismError
+
+
+class IngestionConfigError(VPrismError):
+    """Raised when ingestion configuration is invalid for a batch."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, "INGESTION_CONFIG_ERROR")
+
+
+@dataclass(slots=True, frozen=True)
+class IngestionConfig:
+    """Runtime configuration toggles controlling ingestion behaviour."""
+
+    max_batch_rows: int | None = None
+    enforce_monotonic_ts: bool = True
+    allow_duplicates: bool = False
+
+    def validate_batch_size(self, batch_size: int) -> None:
+        """Ensure the configured batch size limit is respected."""
+
+        if self.max_batch_rows is None:
+            return
+        if self.max_batch_rows <= 0:
+            raise IngestionConfigError("max_batch_rows must be positive when provided")
+        if batch_size > self.max_batch_rows:
+            raise IngestionConfigError(f"batch size {batch_size} exceeds configured limit {self.max_batch_rows}")

--- a/vprism/core/data/ingestion/models.py
+++ b/vprism/core/data/ingestion/models.py
@@ -1,0 +1,26 @@
+"""Data models supporting raw ingestion pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+@dataclass(slots=True)
+class RawRecord:
+    """Represents a single OHLCV observation supplied by an upstream provider."""
+
+    supplier_symbol: str
+    timestamp: datetime
+    open: float | None
+    high: float | None
+    low: float | None
+    close: float | None
+    volume: float | None = None
+    provider: str | None = None
+
+
+__all__ = ["RawRecord"]

--- a/vprism/core/data/ingestion/service.py
+++ b/vprism/core/data/ingestion/service.py
@@ -1,0 +1,170 @@
+"""Ingestion service that validates and persists raw OHLCV batches."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Sequence  # noqa: TC003
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from time import perf_counter
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+try:  # pragma: no cover - optional at runtime for typing.
+    from duckdb import DuckDBPyConnection
+except Exception:  # pragma: no cover
+    DuckDBPyConnection = "DuckDBPyConnection"  # type: ignore[misc,assignment]
+
+from vprism.core.data.ingestion.config import IngestionConfig
+from vprism.core.data.ingestion.validator import (
+    ValidatedRecord,
+    ValidationIssue,
+    validate_batch,
+)
+from vprism.core.data.schema import RAW_OHLCV_TABLE
+
+if TYPE_CHECKING:
+    from vprism.core.data.ingestion.models import RawRecord
+
+
+@dataclass(slots=True, frozen=True)
+class FailureSummary:
+    """Aggregated failure counts grouped by validation code."""
+
+    code: str
+    count: int
+
+
+@dataclass(slots=True, frozen=True)
+class IngestionResult:
+    """Result payload returned after running an ingestion batch."""
+
+    batch_id: str
+    written_rows: int
+    rejected_rows: int
+    duration_ms: float
+    fail_reasons: tuple[FailureSummary, ...]
+    issues: tuple[ValidationIssue, ...]
+    duplicates_dropped: int = 0
+
+
+def _prepare_rows(
+    records: Sequence[ValidatedRecord],
+    *,
+    market: str,
+    provider: str,
+    batch_id: str,
+    ingest_time: datetime,
+) -> list[tuple[object, ...]]:
+    rows: list[tuple[object, ...]] = []
+    for validated in records:
+        record = validated.record
+        rows.append(
+            (
+                record.supplier_symbol,
+                market,
+                record.timestamp,
+                record.open,
+                record.high,
+                record.low,
+                record.close,
+                record.volume,
+                record.provider or provider,
+                batch_id,
+                ingest_time,
+            )
+        )
+    return rows
+
+
+def _summarise(counter: Counter[str]) -> tuple[FailureSummary, ...]:
+    summaries = [FailureSummary(code=code, count=count) for code, count in counter.items()]
+    summaries.sort(key=lambda item: (-item.count, item.code))
+    return tuple(summaries)
+
+
+def ingest(
+    conn: DuckDBPyConnection,
+    records: Iterable[RawRecord],
+    *,
+    provider: str,
+    market: str,
+    config: IngestionConfig | None = None,
+) -> IngestionResult:
+    """Validate incoming records and persist successful rows into DuckDB."""
+
+    config = config or IngestionConfig()
+
+    batch_records = list(records)
+    config.validate_batch_size(len(batch_records))
+
+    start = perf_counter()
+    batch_id = uuid4().hex
+    ingest_time = datetime.now(UTC)
+
+    validated, issues = validate_batch(
+        batch_records,
+        market=market,
+        enforce_monotonic_ts=config.enforce_monotonic_ts,
+    )
+
+    issue_counter: Counter[str] = Counter(issue.code for issue in issues)
+    fatal_indexes = {issue.index for issue in issues if issue.fatal}
+
+    deduped: list[ValidatedRecord] = []
+    duplicates_dropped = 0
+    seen_keys: set[tuple[str, str, datetime]] = set()
+    for validated_record in validated:
+        record = validated_record.record
+        key = (record.supplier_symbol, market, record.timestamp)
+        if key in seen_keys:
+            duplicates_dropped += 1
+            issue_counter["DUPLICATE_ROW"] += 1
+            is_fatal = not config.allow_duplicates
+            if is_fatal:
+                fatal_indexes.add(validated_record.index)
+            issues.append(
+                ValidationIssue(
+                    index=validated_record.index,
+                    field="timestamp",
+                    code="DUPLICATE_ROW",
+                    message="duplicate supplier_symbol/market/timestamp within batch",
+                    fatal=is_fatal,
+                )
+            )
+            continue
+        seen_keys.add(key)
+        deduped.append(validated_record)
+
+    rows_to_insert = _prepare_rows(
+        [record for record in deduped if record.index not in fatal_indexes],
+        market=market,
+        provider=provider,
+        batch_id=batch_id,
+        ingest_time=ingest_time,
+    )
+
+    written_rows = 0
+    if rows_to_insert:
+        RAW_OHLCV_TABLE.ensure(conn)
+        conn.executemany(
+            (
+                "INSERT INTO raw_ohlcv (supplier_symbol, market, ts, open, high, low, close, volume, provider, batch_id, ingest_time) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            rows_to_insert,
+        )
+        written_rows = len(rows_to_insert)
+
+    rejected_rows = len(fatal_indexes)
+    duration_ms = (perf_counter() - start) * 1000
+
+    return IngestionResult(
+        batch_id=batch_id,
+        written_rows=written_rows,
+        rejected_rows=rejected_rows,
+        duration_ms=duration_ms,
+        fail_reasons=_summarise(issue_counter),
+        issues=tuple(issues),
+        duplicates_dropped=duplicates_dropped,
+    )

--- a/vprism/core/data/ingestion/validator.py
+++ b/vprism/core/data/ingestion/validator.py
@@ -1,0 +1,225 @@
+"""Validation utilities for raw OHLCV ingestion batches."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence  # noqa: TC003
+from dataclasses import dataclass
+from math import isfinite
+from typing import TYPE_CHECKING
+
+from vprism.core.data.ingestion.models import RawRecord
+
+_DEFAULT_VOLUME = -1.0
+_EPSILON = 1e-12
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+@dataclass(slots=True, frozen=True)
+class ValidationIssue:
+    """Represents a single validation issue detected during ingestion."""
+
+    index: int
+    field: str
+    code: str
+    message: str
+    fatal: bool = True
+
+
+@dataclass(slots=True)
+class ValidatedRecord:
+    """Container mapping an input index to its sanitised record."""
+
+    index: int
+    record: RawRecord
+
+
+def _is_missing(value: object) -> bool:
+    return value is None
+
+
+def _ensure_finite(value: float) -> bool:
+    return isfinite(value)
+
+
+def _violates_low_high(low: float, high: float) -> bool:
+    return (low - high) > _EPSILON
+
+
+def _above_high(value: float, high: float) -> bool:
+    return (value - high) > _EPSILON
+
+
+def _below_low(value: float, low: float) -> bool:
+    return (low - value) > _EPSILON
+
+
+def validate_batch(
+    records: Sequence[RawRecord],
+    *,
+    market: str,
+    enforce_monotonic_ts: bool = True,
+) -> tuple[list[ValidatedRecord], list[ValidationIssue]]:
+    """Validate a batch of records and return sanitised successes with issues."""
+
+    issues: list[ValidationIssue] = []
+    validated: list[ValidatedRecord] = []
+    last_ts_by_symbol: dict[tuple[str, str], datetime] = {}
+
+    for index, record in enumerate(records):
+        fatal = False
+        symbol = record.supplier_symbol
+        timestamp = record.timestamp
+
+        if not symbol:
+            issues.append(
+                ValidationIssue(
+                    index=index,
+                    field="supplier_symbol",
+                    code="MISSING_FIELD",
+                    message="supplier_symbol is required",
+                )
+            )
+            fatal = True
+
+        if timestamp is None:
+            issues.append(
+                ValidationIssue(
+                    index=index,
+                    field="timestamp",
+                    code="MISSING_FIELD",
+                    message="timestamp is required",
+                )
+            )
+            fatal = True
+
+        numeric_fields = {
+            "open": record.open,
+            "high": record.high,
+            "low": record.low,
+            "close": record.close,
+        }
+        for field, value in numeric_fields.items():
+            if _is_missing(value):
+                issues.append(
+                    ValidationIssue(
+                        index=index,
+                        field=field,
+                        code="MISSING_FIELD",
+                        message=f"{field} is required",
+                    )
+                )
+                fatal = True
+                continue
+            if not _ensure_finite(value):
+                issues.append(
+                    ValidationIssue(
+                        index=index,
+                        field=field,
+                        code="NON_FINITE_VALUE",
+                        message=f"{field} must be finite",
+                    )
+                )
+                fatal = True
+
+        if not fatal:
+            assert record.low is not None
+            assert record.high is not None
+            assert record.open is not None
+            assert record.close is not None
+
+            low = record.low
+            high = record.high
+            open_ = record.open
+            close = record.close
+
+            if _violates_low_high(low, high):
+                issues.append(
+                    ValidationIssue(
+                        index=index,
+                        field="low_high",
+                        code="LOW_ABOVE_HIGH",
+                        message="low price cannot exceed high price",
+                    )
+                )
+                fatal = True
+            else:
+                if _above_high(open_, high) or _below_low(open_, low):
+                    issues.append(
+                        ValidationIssue(
+                            index=index,
+                            field="open",
+                            code="OPEN_OUT_OF_RANGE",
+                            message="open price must lie within [low, high]",
+                        )
+                    )
+                    fatal = True
+                if _above_high(close, high) or _below_low(close, low):
+                    issues.append(
+                        ValidationIssue(
+                            index=index,
+                            field="close",
+                            code="CLOSE_OUT_OF_RANGE",
+                            message="close price must lie within [low, high]",
+                        )
+                    )
+                    fatal = True
+
+        volume = record.volume
+        if volume is None:
+            issues.append(
+                ValidationIssue(
+                    index=index,
+                    field="volume",
+                    code="MISSING_VOLUME_DEFAULTED",
+                    message="volume missing; defaulted to -1",
+                    fatal=False,
+                )
+            )
+            volume = _DEFAULT_VOLUME
+        else:
+            if not _ensure_finite(volume) or volume < 0 and abs(volume - _DEFAULT_VOLUME) > _EPSILON:
+                issues.append(
+                    ValidationIssue(
+                        index=index,
+                        field="volume",
+                        code="NEGATIVE_VOLUME",
+                        message="volume must be non-negative",
+                    )
+                )
+                fatal = True
+
+        symbol_key = (market, symbol) if symbol else None
+
+        if enforce_monotonic_ts and not fatal and symbol_key:
+            previous = last_ts_by_symbol.get(symbol_key)
+            if previous is not None and timestamp < previous:
+                issues.append(
+                    ValidationIssue(
+                        index=index,
+                        field="timestamp",
+                        code="NON_MONOTONIC_TIMESTAMP",
+                        message="timestamps must be non-decreasing per symbol",
+                    )
+                )
+                fatal = True
+            else:
+                last_ts_by_symbol[symbol_key] = timestamp
+        elif symbol_key and timestamp is not None:
+            last_ts_by_symbol[symbol_key] = timestamp
+
+        if not fatal:
+            sanitised = RawRecord(
+                supplier_symbol=symbol,
+                timestamp=timestamp,
+                open=record.open,
+                high=record.high,
+                low=record.low,
+                close=record.close,
+                volume=volume,
+                provider=record.provider,
+            )
+            validated.append(ValidatedRecord(index=index, record=sanitised))
+
+    return validated, issues

--- a/vprism/core/data/providers/__init__.py
+++ b/vprism/core/data/providers/__init__.py
@@ -17,6 +17,7 @@ from vprism.core.data.providers.factory import (
 from vprism.core.data.providers.registry import ProviderRegistry
 
 # from .vprism import VPrism  # vprism provider no longer exists
+from vprism.core.data.providers.stub_provider import StubProviderRow, VPrismStubProvider
 from vprism.core.data.providers.yfinance import YFinance
 
 __all__ = [
@@ -33,4 +34,6 @@ __all__ = [
     "AkShare",
     # "VPrism",
     "AlphaVantage",
+    "VPrismStubProvider",
+    "StubProviderRow",
 ]

--- a/vprism/core/data/providers/stub_provider.py
+++ b/vprism/core/data/providers/stub_provider.py
@@ -1,0 +1,116 @@
+"""Stub data provider for injecting baseline OHLCV rows into DuckDB."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+try:  # pragma: no cover - optional import for static analysis environments
+    from duckdb import DuckDBPyConnection
+except Exception:  # pragma: no cover
+    DuckDBPyConnection = "DuckDBPyConnection"  # type: ignore[misc,assignment]
+
+from vprism.core.data.schema import RAW_BASE_TABLE, TableSchema
+from vprism.core.exceptions.base import DataValidationError
+
+
+@dataclass(frozen=True)
+class StubProviderRow:
+    """Typed representation of a stub provider row."""
+
+    supplier_symbol: str
+    timestamp: object
+    open: float | None = None
+    high: float | None = None
+    low: float | None = None
+    close: float | None = None
+    volume: float | None = None
+    provider: str = "stub"
+
+    def as_mapping(self) -> Mapping[str, object]:
+        """Return the row as a mapping compatible with DuckDB inserts."""
+
+        return {
+            "supplier_symbol": self.supplier_symbol,
+            "timestamp": self.timestamp,
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+            "provider": self.provider,
+        }
+
+
+class VPrismStubProvider:
+    """Utility for seeding DuckDB tables with deterministic stub rows."""
+
+    def __init__(
+        self,
+        conn: DuckDBPyConnection,
+        table_schema: TableSchema = RAW_BASE_TABLE,
+        provider_name: str = "stub",
+    ) -> None:
+        self._conn = conn
+        self._table_schema = table_schema
+        self._provider_name = provider_name
+
+    def ingest_rows(self, rows: Sequence[Mapping[str, object] | StubProviderRow]) -> None:
+        """Insert validated rows into the configured DuckDB table."""
+
+        normalized_rows = [self._normalize_row(row) for row in rows]
+        validation_errors = list(self._validate_rows(normalized_rows))
+        if validation_errors:
+            raise DataValidationError(
+                message="Stub provider detected invalid rows.",
+                validation_errors={"rows": validation_errors},
+                details={
+                    "provider": self._provider_name,
+                    "table": self._table_schema.name,
+                },
+            )
+
+        self._table_schema.ensure(self._conn)
+        column_names = [column.name for column in self._table_schema.columns]
+        placeholders = ", ".join(["?"] * len(column_names))
+        insert_sql = (
+            f"INSERT INTO {self._table_schema.name} "
+            f"({', '.join(column_names)}) VALUES ({placeholders})"
+        )
+        parameters = [[row.get(name) for name in column_names] for row in normalized_rows]
+        if parameters:
+            self._conn.executemany(insert_sql, parameters)
+
+    def _normalize_row(
+        self, row: Mapping[str, object] | StubProviderRow
+    ) -> Mapping[str, object]:
+        if isinstance(row, StubProviderRow):
+            return row.as_mapping()
+        return dict(row)
+
+    def _validate_rows(
+        self, rows: Iterable[Mapping[str, object]]
+    ) -> Iterable[Mapping[str, object]]:
+        required_columns = {
+            column.name
+            for column in self._table_schema.columns
+            if "NOT NULL" in {constraint.upper() for constraint in column.constraints}
+        }
+        valid_columns = {column.name for column in self._table_schema.columns}
+        for index, row in enumerate(rows):
+            missing_required = [
+                column
+                for column in required_columns
+                if row.get(column) is None
+            ]
+            unexpected = sorted(set(row.keys()) - valid_columns)
+            if missing_required or unexpected:
+                error_payload: dict[str, object] = {"index": index}
+                if missing_required:
+                    error_payload["missing_fields"] = sorted(missing_required)
+                if unexpected:
+                    error_payload["unexpected_fields"] = unexpected
+                yield error_payload
+
+
+__all__ = ["VPrismStubProvider", "StubProviderRow"]

--- a/vprism/core/data/schema.py
+++ b/vprism/core/data/schema.py
@@ -1,0 +1,189 @@
+"""Core schema definitions for baseline OHLCV datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence  # noqa: TC003
+from dataclasses import dataclass
+
+try:  # pragma: no cover - duckdb is optional at import time for type checking.
+    from duckdb import DuckDBPyConnection
+except Exception:  # pragma: no cover
+    DuckDBPyConnection = "DuckDBPyConnection"  # type: ignore[misc,assignment]
+
+
+@dataclass(frozen=True)
+class ColumnDef:
+    """Represents a DuckDB table column definition."""
+
+    name: str
+    data_type: str
+    constraints: Sequence[str] = ()
+
+    def render(self) -> str:
+        parts = [self.name, self.data_type, *self.constraints]
+        return " ".join(parts)
+
+
+@dataclass(frozen=True)
+class TableSchema:
+    """Utility wrapper describing a DuckDB table schema."""
+
+    name: str
+    columns: Sequence[ColumnDef]
+    primary_key: Sequence[str] = ()
+
+    def create_ddl(self) -> str:
+        column_defs: list[str] = [column.render() for column in self.columns]
+        if self.primary_key:
+            pk_cols = ", ".join(self.primary_key)
+            column_defs.append(f"PRIMARY KEY ({pk_cols})")
+        columns_sql = ",\n                ".join(column_defs)
+        return f"""
+            CREATE TABLE IF NOT EXISTS {self.name} (
+                {columns_sql}
+            )
+            """.strip()
+
+    def ensure(self, conn: DuckDBPyConnection) -> None:
+        """Create the table on the provided connection if it does not exist."""
+
+        conn.execute(self.create_ddl())
+
+
+RAW_BASE_TABLE = TableSchema(
+    name="raw_schema",
+    columns=(
+        ColumnDef("supplier_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("timestamp", "TIMESTAMP", ("NOT NULL",)),
+        ColumnDef("open", "DOUBLE"),
+        ColumnDef("high", "DOUBLE"),
+        ColumnDef("low", "DOUBLE"),
+        ColumnDef("close", "DOUBLE"),
+        ColumnDef("volume", "DOUBLE"),
+        ColumnDef("provider", "VARCHAR"),
+    ),
+)
+
+NORMALIZATION_BASE_TABLE = TableSchema(
+    name="normalization_schema",
+    columns=(
+        ColumnDef("supplier_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("timestamp", "TIMESTAMP", ("NOT NULL",)),
+        ColumnDef("open", "DOUBLE"),
+        ColumnDef("high", "DOUBLE"),
+        ColumnDef("low", "DOUBLE"),
+        ColumnDef("close", "DOUBLE"),
+        ColumnDef("volume", "DOUBLE"),
+        ColumnDef("provider", "VARCHAR"),
+        ColumnDef("market", "VARCHAR"),
+        ColumnDef("tz_offset", "INTEGER"),
+        ColumnDef("currency", "VARCHAR"),
+        ColumnDef("c_symbol", "VARCHAR"),
+    ),
+)
+
+SYMBOL_MAP_TABLE = TableSchema(
+    name="symbol_map",
+    columns=(
+        ColumnDef("c_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("raw_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("market", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("asset_type", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("provider_hint", "VARCHAR"),
+        ColumnDef("rule_id", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("created_at", "TIMESTAMP", ("NOT NULL",)),
+    ),
+    primary_key=("c_symbol", "raw_symbol"),
+)
+
+RAW_OHLCV_TABLE = TableSchema(
+    name="raw_ohlcv",
+    columns=(
+        ColumnDef("supplier_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("market", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("ts", "TIMESTAMP", ("NOT NULL",)),
+        ColumnDef("open", "DOUBLE"),
+        ColumnDef("high", "DOUBLE"),
+        ColumnDef("low", "DOUBLE"),
+        ColumnDef("close", "DOUBLE"),
+        ColumnDef("volume", "DOUBLE"),
+        ColumnDef("provider", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("batch_id", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("ingest_time", "TIMESTAMP", ("NOT NULL",)),
+    ),
+    primary_key=("supplier_symbol", "market", "ts", "batch_id"),
+)
+
+
+CORPORATE_ACTIONS_TABLE = TableSchema(
+    name="corporate_actions",
+    columns=(
+        ColumnDef("market", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("supplier_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("event_type", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("effective_date", "DATE", ("NOT NULL",)),
+        ColumnDef("dividend_cash", "DOUBLE"),
+        ColumnDef("split_ratio", "DOUBLE"),
+        ColumnDef("raw_payload", "JSON"),
+        ColumnDef("source", "VARCHAR"),
+        ColumnDef("batch_id", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("ingest_time", "TIMESTAMP", ("NOT NULL",)),
+    ),
+    primary_key=("market", "supplier_symbol", "event_type", "effective_date", "batch_id"),
+)
+
+
+ADJUSTMENTS_TABLE = TableSchema(
+    name="adjustments",
+    columns=(
+        ColumnDef("market", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("supplier_symbol", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("date", "DATE", ("NOT NULL",)),
+        ColumnDef("adj_factor_qfq", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("adj_factor_hfq", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("version", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("build_time", "TIMESTAMP", ("NOT NULL",)),
+        ColumnDef("source_events_hash", "VARCHAR", ("NOT NULL",)),
+    ),
+    primary_key=("market", "supplier_symbol", "date", "version"),
+)
+
+
+def baseline_tables() -> Sequence[TableSchema]:
+    """Return the schemas that compose the PRD-0 baseline."""
+
+    return (RAW_BASE_TABLE, NORMALIZATION_BASE_TABLE)
+
+
+def ensure_baseline_tables(conn: DuckDBPyConnection) -> None:
+    """Create all baseline tables on the provided DuckDB connection."""
+
+    for table in baseline_tables():
+        table.ensure(conn)
+
+
+def create_baseline_ddl() -> Iterable[str]:
+    """Yield CREATE TABLE statements for the baseline schemas."""
+
+    for table in baseline_tables():
+        yield table.create_ddl()
+
+
+def corporate_action_tables() -> Sequence[TableSchema]:
+    """Return the schemas used for corporate action storage and factors."""
+
+    return (CORPORATE_ACTIONS_TABLE, ADJUSTMENTS_TABLE)
+
+
+def ensure_corporate_action_tables(conn: DuckDBPyConnection) -> None:
+    """Create corporate action-related tables on the provided connection."""
+
+    for table in corporate_action_tables():
+        table.ensure(conn)
+
+
+def create_corporate_action_ddl() -> Iterable[str]:
+    """Yield CREATE TABLE statements for corporate action storage."""
+
+    for table in corporate_action_tables():
+        yield table.create_ddl()

--- a/vprism/core/data/storage/duckdb_factory.py
+++ b/vprism/core/data/storage/duckdb_factory.py
@@ -1,0 +1,59 @@
+"""Utility helpers for creating DuckDB connections in tests and local runs."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, Mapping
+
+import duckdb
+
+try:  # pragma: no cover - type checking compatibility
+    from duckdb import DuckDBPyConnection
+except Exception:  # pragma: no cover
+    DuckDBPyConnection = "DuckDBPyConnection"  # type: ignore[misc,assignment]
+
+
+@dataclass(frozen=True)
+class DuckDBFactoryConfig:
+    """Configuration applied to DuckDB connections produced by the factory."""
+
+    database: str | Path = ":memory:"
+    read_only: bool = False
+    pragmas: Mapping[str, object] = field(
+        default_factory=lambda: {"threads": 1}
+    )
+
+
+class VPrismDuckDBFactory:
+    """Factory that yields configured DuckDB connections."""
+
+    def __init__(self, config: DuckDBFactoryConfig | None = None) -> None:
+        self._config = config or DuckDBFactoryConfig()
+
+    def create_connection(self) -> DuckDBPyConnection:
+        """Create and return a configured DuckDB connection."""
+
+        conn = duckdb.connect(
+            database=str(self._config.database), read_only=self._config.read_only
+        )
+        self._apply_pragmas(conn)
+        return conn
+
+    @contextmanager
+    def connection(self) -> Iterator[DuckDBPyConnection]:
+        """Context manager that yields a configured DuckDB connection."""
+
+        conn = self.create_connection()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _apply_pragmas(self, conn: DuckDBPyConnection) -> None:
+        for setting, value in self._config.pragmas.items():
+            conn.execute(f"SET {setting}=?", [value])
+
+
+__all__ = ["VPrismDuckDBFactory", "DuckDBFactoryConfig"]

--- a/vprism/core/exceptions/base.py
+++ b/vprism/core/exceptions/base.py
@@ -72,6 +72,21 @@ class DataValidationError(VPrismError):
         self.validation_errors = validation_errors or {}
 
 
+class AdjustmentInputError(VPrismError):
+    """Adjustment computation input is insufficient for processing."""
+
+    def __init__(
+        self,
+        message: str,
+        symbol: str,
+        market: str,
+        details: dict[str, Any] | None = None,
+    ):
+        super_details = details or {}
+        super_details.update({"symbol": symbol, "market": market})
+        super().__init__(message, "ADJUSTMENT_INPUT_ERROR", super_details)
+
+
 class NoCapableProviderError(VPrismError):
     """没有可用提供商异常."""
 
@@ -147,3 +162,28 @@ class NetworkError(ProviderError):
         if status_code is not None:
             super_details["status_code"] = status_code
         super().__init__(message, provider_name, "NETWORK_ERROR", super_details)
+
+
+class UnresolvedSymbolError(VPrismError):
+    """符号规范化失败异常."""
+
+    def __init__(
+        self,
+        message: str,
+        raw_symbol: str,
+        market: str,
+        asset_type: str,
+        details: dict[str, Any] | None = None,
+    ):
+        super_details = details or {}
+        super_details.update(
+            {
+                "raw_symbol": raw_symbol,
+                "market": market,
+                "asset_type": asset_type,
+            }
+        )
+        super().__init__(message, "SYMBOL_UNRESOLVED", super_details)
+        self.raw_symbol = raw_symbol
+        self.market = market
+        self.asset_type = asset_type

--- a/vprism/core/models/corporate_actions.py
+++ b/vprism/core/models/corporate_actions.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from datetime import date
+from collections import defaultdict
+from collections.abc import Sequence  # noqa: TC003
+from dataclasses import dataclass
+from datetime import date  # noqa: TC003
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from vprism.core.models.market import MarketType
+from vprism.core.models.market import MarketType  # noqa: TC001
+
+if TYPE_CHECKING:
+    from vprism.core.models.base import DataPoint
+    from vprism.core.models.query import Adjustment
 
 
 class DividendEvent(BaseModel):
@@ -43,31 +50,143 @@ class CorporateActionFactor(BaseModel):
     source: str | None = None
 
 
+@dataclass(slots=True, frozen=True)
+class CorporateActionSet:
+    """Container for dividend and split events for a symbol."""
+
+    dividends: Sequence[DividendEvent]
+    splits: Sequence[SplitEvent]
+
+
+@dataclass(slots=True, frozen=True)
+class FactorComputation:
+    """Result of computing corporate action adjustment factors."""
+
+    factors: list[CorporateActionFactor]
+    gap_dates: tuple[date, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class AdjustmentRow:
+    """Single-day adjustment output containing raw and adjusted prices."""
+
+    date: date
+    close_raw: Decimal | None
+    close_qfq: Decimal | None
+    close_hfq: Decimal | None
+    adj_factor_qfq: Decimal
+    adj_factor_hfq: Decimal
+
+
+@dataclass(slots=True, frozen=True)
+class AdjustmentResult:
+    """Adjustment computation output along with factor metadata."""
+
+    symbol: str
+    market: MarketType
+    mode: Adjustment
+    rows: tuple[AdjustmentRow, ...]
+    factors: tuple[CorporateActionFactor, ...]
+    source_events_hash: str
+    version: str
+    action_gap_flag: bool
+
+
+def _decimal_ratio(value: Decimal, denominator: Decimal) -> Decimal | None:
+    if denominator == 0:
+        return None
+    return value / denominator
+
+
 def compute_corporate_action_factors(
     symbol: str,
     market: MarketType,
-    price_dates: list[date],
-    dividends: list[DividendEvent],
-    splits: list[SplitEvent],
-) -> list[CorporateActionFactor]:
+    prices: Sequence[DataPoint],
+    dividends: Sequence[DividendEvent],
+    splits: Sequence[SplitEvent],
+) -> FactorComputation:
+    if not prices:
+        return FactorComputation(factors=[], gap_dates=())
+
+    sorted_points = sorted(prices, key=lambda point: point.timestamp)
+    dividend_map: dict[date, list[DividendEvent]] = defaultdict(list)
+    for event in dividends:
+        dividend_map[event.ex_date].append(event)
+
+    split_map: dict[date, list[SplitEvent]] = defaultdict(list)
+    for event in splits:
+        split_map[event.ex_date].append(event)
+
+    hfq_factor = Decimal("1")
+    hfq_series: list[Decimal] = []
+    dates: list[date] = []
+    gap_dates: set[date] = set()
+    previous_close: Decimal | None = None
+
+    for point in sorted_points:
+        current_date = point.timestamp.date()
+        for event in dividend_map.get(current_date, []):
+            if previous_close is None:
+                gap_dates.add(current_date)
+                continue
+            ratio_base = _decimal_ratio(event.cash_amount, previous_close)
+            if ratio_base is None:
+                gap_dates.add(current_date)
+                continue
+            adjustment = Decimal("1") - ratio_base
+            if adjustment <= 0:
+                gap_dates.add(current_date)
+                continue
+            hfq_factor = hfq_factor / adjustment
+
+        for event in split_map.get(current_date, []):
+            denominator = Decimal(event.denominator)
+            ratio = _decimal_ratio(Decimal(event.numerator), denominator)
+            if ratio is None or ratio <= 0:
+                gap_dates.add(current_date)
+                continue
+            hfq_factor = hfq_factor * ratio
+
+        hfq_series.append(hfq_factor)
+        dates.append(current_date)
+        if point.close_price is not None:
+            previous_close = point.close_price
+
+    event_dates = {event.ex_date for event in dividends} | {event.ex_date for event in splits}
+    missing_dates = event_dates.difference(dates)
+    gap_dates.update(missing_dates)
+
+    if not hfq_series:
+        return FactorComputation(factors=[], gap_dates=tuple(sorted(gap_dates)))
+
+    latest_hfq = hfq_series[-1]
+    if latest_hfq == 0:
+        # Avoid division by zero when normalizing for qfq factors.
+        latest_hfq = Decimal("1")
+
     factors: list[CorporateActionFactor] = []
-    for d in price_dates:
+    for current_date, hfq_value in zip(dates, hfq_series, strict=False):
+        qfq_factor = hfq_value / latest_hfq if latest_hfq != 0 else Decimal("0")
         factors.append(
             CorporateActionFactor(
                 symbol=symbol,
                 market=market,
-                date=d,
-                forward_factor=Decimal("1"),
-                backward_factor=Decimal("1"),
-                source="placeholder",
+                date=current_date,
+                forward_factor=qfq_factor,
+                backward_factor=hfq_value,
             )
         )
-    return factors
+
+    return FactorComputation(factors=factors, gap_dates=tuple(sorted(gap_dates)))
 
 
 __all__ = [
     "DividendEvent",
     "SplitEvent",
     "CorporateActionFactor",
+    "CorporateActionSet",
+    "FactorComputation",
+    "AdjustmentRow",
+    "AdjustmentResult",
     "compute_corporate_action_factors",
 ]

--- a/vprism/core/models/symbols.py
+++ b/vprism/core/models/symbols.py
@@ -1,0 +1,84 @@
+"""Data models supporting the symbol normalization service."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from re import Pattern
+from typing import TYPE_CHECKING, Literal
+
+RuleTransform = Callable[[str, re.Match[str]], str]
+
+
+if TYPE_CHECKING:
+    from vprism.core.exceptions.base import UnresolvedSymbolError
+    from vprism.core.models.market import AssetType, MarketType
+
+
+@dataclass(frozen=True)
+class CanonicalSymbol:
+    """Represents a canonical symbol produced by the normalization service."""
+
+    raw_symbol: str
+    canonical: str
+    market: MarketType
+    asset_type: AssetType
+    rule_id: str
+
+
+@dataclass(frozen=True)
+class SymbolRule:
+    """Normalization rule evaluated by :class:`SymbolService`."""
+
+    id: str
+    priority: int
+    pattern: Pattern[str]
+    transform: RuleTransform
+    market_scope: frozenset[MarketType] = frozenset()
+    asset_scope: frozenset[AssetType] = frozenset()
+    prefix: str | None = None
+    suffix: str | None = None
+
+    def applies_to(self, market: MarketType, asset_type: AssetType) -> bool:
+        """Return whether the rule is applicable for the provided context."""
+
+        market_allowed = not self.market_scope or market in self.market_scope
+        asset_allowed = not self.asset_scope or asset_type in self.asset_scope
+        return market_allowed and asset_allowed
+
+
+@dataclass(frozen=True)
+class BatchNormalizationItem:
+    """Represents the outcome for a single symbol in a batch request."""
+
+    raw_symbol: str
+    status: Literal["resolved", "unresolved"]
+    canonical: CanonicalSymbol | None = None
+    error: UnresolvedSymbolError | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == "resolved" and self.canonical is None:
+            raise ValueError("Resolved batch items require a canonical symbol.")
+        if self.status == "unresolved" and self.error is None:
+            raise ValueError("Unresolved batch items require an associated error.")
+
+
+@dataclass(frozen=True)
+class BatchNormalizationResult:
+    """Aggregated result payload for batch normalization operations."""
+
+    market: MarketType
+    asset_type: AssetType
+    items: tuple[BatchNormalizationItem, ...]
+    successes: tuple[CanonicalSymbol, ...]
+    failures: tuple[UnresolvedSymbolError, ...]
+
+
+__all__ = [
+    "CanonicalSymbol",
+    "SymbolRule",
+    "RuleTransform",
+    "BatchNormalizationItem",
+    "BatchNormalizationResult",
+]

--- a/vprism/core/services/adjustment_engine.py
+++ b/vprism/core/services/adjustment_engine.py
@@ -1,0 +1,148 @@
+"""Adjustment engine for computing forward/backward adjusted price series."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Sequence
+from datetime import date
+from decimal import Decimal
+
+from vprism.core.exceptions.base import AdjustmentInputError
+from vprism.core.models.base import DataPoint
+from vprism.core.models.corporate_actions import (
+    AdjustmentResult,
+    AdjustmentRow,
+    CorporateActionFactor,
+    CorporateActionSet,
+    FactorComputation,
+    compute_corporate_action_factors,
+)
+from vprism.core.models.market import MarketType
+from vprism.core.models.query import Adjustment
+
+PriceLoader = Callable[[str, MarketType, date, date], Sequence[DataPoint]]
+CorporateActionLoader = Callable[[str, MarketType, date, date], CorporateActionSet]
+
+
+def _format_decimal(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _hash_events(action_set: CorporateActionSet) -> str:
+    parts: list[str] = []
+    for event in sorted(
+        action_set.dividends,
+        key=lambda item: (item.ex_date, _format_decimal(item.cash_amount), item.currency or "", item.source or ""),
+    ):
+        parts.append(
+            "|".join(
+                (
+                    "dividend",
+                    event.ex_date.isoformat(),
+                    _format_decimal(event.cash_amount),
+                    event.currency or "",
+                    event.source or "",
+                )
+            )
+        )
+    for event in sorted(
+        action_set.splits,
+        key=lambda item: (item.ex_date, item.numerator, item.denominator, item.source or ""),
+    ):
+        parts.append(
+            "|".join(
+                (
+                    "split",
+                    event.ex_date.isoformat(),
+                    str(event.numerator),
+                    str(event.denominator),
+                    event.source or "",
+                )
+            )
+        )
+    payload = "\n".join(parts).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class AdjustmentEngine:
+    """Compute adjustment factors and adjusted prices for a symbol."""
+
+    def __init__(
+        self,
+        price_loader: PriceLoader,
+        action_loader: CorporateActionLoader,
+        algorithm_version: int = 1,
+    ) -> None:
+        self._price_loader = price_loader
+        self._action_loader = action_loader
+        self._algorithm_version = algorithm_version
+
+    def compute(
+        self,
+        symbol: str,
+        market: MarketType,
+        start: date,
+        end: date,
+        mode: Adjustment = Adjustment.NONE,
+    ) -> AdjustmentResult:
+        prices = list(self._price_loader(symbol, market, start, end))
+        if not prices:
+            raise AdjustmentInputError(
+                "No price data available for adjustment computation.",
+                symbol=symbol,
+                market=market.value,
+            )
+
+        prices.sort(key=lambda point: point.timestamp)
+        action_set = self._action_loader(symbol, market, start, end)
+
+        factor_result: FactorComputation = compute_corporate_action_factors(
+            symbol,
+            market,
+            prices,
+            action_set.dividends,
+            action_set.splits,
+        )
+        factor_map: dict[date, CorporateActionFactor] = {
+            factor.date: factor for factor in factor_result.factors
+        }
+
+        rows: list[AdjustmentRow] = []
+        for point in prices:
+            price_date = point.timestamp.date()
+            factor = factor_map.get(price_date)
+            adj_qfq = factor.forward_factor if factor else Decimal("1")
+            adj_hfq = factor.backward_factor if factor else Decimal("1")
+            close_raw = point.close_price
+            close_qfq = close_raw * adj_qfq if close_raw is not None else None
+            close_hfq = close_raw * adj_hfq if close_raw is not None else None
+            rows.append(
+                AdjustmentRow(
+                    date=price_date,
+                    close_raw=close_raw,
+                    close_qfq=close_qfq,
+                    close_hfq=close_hfq,
+                    adj_factor_qfq=adj_qfq,
+                    adj_factor_hfq=adj_hfq,
+                )
+            )
+
+        events_hash = _hash_events(action_set)
+        version = f"{self._algorithm_version}:{events_hash[:12]}"
+
+        return AdjustmentResult(
+            symbol=symbol,
+            market=market,
+            mode=mode,
+            rows=tuple(rows),
+            factors=tuple(factor_result.factors),
+            source_events_hash=events_hash,
+            version=version,
+            action_gap_flag=bool(factor_result.gap_dates),
+        )
+
+
+__all__ = ["AdjustmentEngine"]

--- a/vprism/core/services/symbol_rule_loader.py
+++ b/vprism/core/services/symbol_rule_loader.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from string import Formatter
+from typing import Any
+
+from vprism.core.exceptions.base import DataValidationError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.models.symbols import RuleTransform, SymbolRule
+
+_ALLOWED_FILE_SUFFIXES = {".yaml", ".yml", ".json"}
+
+
+class _TemplateDict(dict[str, str]):
+    """Dictionary used for formatting to ensure strict key access."""
+
+    def __missing__(self, key: str) -> str:  # pragma: no cover - defensive
+        raise KeyError(key)
+
+
+def load_symbol_rules(path: str | Path) -> tuple[SymbolRule, ...]:
+    """Load symbol normalization rules from a YAML or JSON file."""
+
+    file_path = Path(path)
+    if not file_path.exists():
+        raise DataValidationError(
+            "Symbol rule configuration file does not exist.",
+            details={"path": str(file_path)},
+        )
+
+    suffix = file_path.suffix.lower()
+    if suffix not in _ALLOWED_FILE_SUFFIXES:
+        raise DataValidationError(
+            "Unsupported symbol rule file type.",
+            details={"path": str(file_path), "suffix": suffix},
+        )
+
+    content = file_path.read_text(encoding="utf-8")
+    config: Any
+    if suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover - environment guard
+            raise DataValidationError(
+                "PyYAML is required to load YAML rule files.",
+                details={"path": str(file_path)},
+            ) from exc
+        config = yaml.safe_load(content)
+    else:
+        config = json.loads(content)
+
+    if config is None:
+        raise DataValidationError(
+            "Symbol rule configuration must not be empty.",
+            details={"path": str(file_path)},
+        )
+
+    if not isinstance(config, Mapping):
+        raise DataValidationError(
+            "Symbol rule configuration must be a mapping at the top level.",
+            details={"path": str(file_path)},
+        )
+
+    return load_symbol_rules_from_mapping(config)
+
+
+def load_symbol_rules_from_mapping(config: Mapping[str, Any]) -> tuple[SymbolRule, ...]:
+    """Convert a configuration mapping into :class:`SymbolRule` instances."""
+
+    raw_rules = config.get("rules")
+    if not isinstance(raw_rules, list):
+        raise DataValidationError(
+            "Symbol rule configuration requires a 'rules' list.",
+            details={"provided_type": type(raw_rules).__name__},
+        )
+
+    rules: list[SymbolRule] = []
+    seen_ids: set[str] = set()
+    for index, raw_rule in enumerate(raw_rules):
+        if not isinstance(raw_rule, Mapping):
+            raise DataValidationError(
+                "Each rule entry must be a mapping.",
+                details={"index": index},
+            )
+        rule = _parse_rule(raw_rule, index)
+        if rule.id in seen_ids:
+            raise DataValidationError(
+                "Duplicate rule identifiers are not allowed.",
+                details={"rule_id": rule.id},
+            )
+        seen_ids.add(rule.id)
+        rules.append(rule)
+
+    return tuple(rules)
+
+
+def _parse_rule(raw_rule: Mapping[str, Any], index: int) -> SymbolRule:
+    rule_id = raw_rule.get("id")
+    if not isinstance(rule_id, str) or not rule_id.strip():
+        raise DataValidationError(
+            "Symbol rule must define a non-empty string 'id'.",
+            details={"index": index},
+        )
+
+    priority = raw_rule.get("priority")
+    if not isinstance(priority, int):
+        raise DataValidationError(
+            "Symbol rule must define an integer 'priority'.",
+            details={"rule_id": rule_id},
+        )
+
+    pattern_value = raw_rule.get("pattern")
+    if not isinstance(pattern_value, str) or not pattern_value:
+        raise DataValidationError(
+            "Symbol rule must define a regex 'pattern'.",
+            details={"rule_id": rule_id},
+        )
+
+    flags_value = raw_rule.get("flags", [])
+    flags = _resolve_regex_flags(flags_value, rule_id)
+    pattern = re.compile(pattern_value, flags)
+
+    transform_spec = raw_rule.get("transform")
+    transform = _parse_transform(transform_spec, pattern, rule_id)
+
+    market_scope = _parse_market_scope(raw_rule.get("market_scope"), rule_id)
+    asset_scope = _parse_asset_scope(raw_rule.get("asset_scope"), rule_id)
+
+    prefix = raw_rule.get("prefix")
+    if prefix is not None and not isinstance(prefix, str):
+        raise DataValidationError(
+            "Symbol rule 'prefix' must be a string when provided.",
+            details={"rule_id": rule_id},
+        )
+
+    suffix = raw_rule.get("suffix")
+    if suffix is not None and not isinstance(suffix, str):
+        raise DataValidationError(
+            "Symbol rule 'suffix' must be a string when provided.",
+            details={"rule_id": rule_id},
+        )
+
+    return SymbolRule(
+        id=rule_id,
+        priority=priority,
+        pattern=pattern,
+        transform=transform,
+        market_scope=market_scope,
+        asset_scope=asset_scope,
+        prefix=prefix,
+        suffix=suffix,
+    )
+
+
+def _resolve_regex_flags(flags_value: Any, rule_id: str) -> int:
+    if flags_value is None:
+        return 0
+    if not isinstance(flags_value, Iterable) or isinstance(flags_value, str | bytes):
+        raise DataValidationError(
+            "Regex flags must be provided as a list of strings.",
+            details={"rule_id": rule_id},
+        )
+
+    resolved = 0
+    for flag_name in flags_value:
+        if not isinstance(flag_name, str):
+            raise DataValidationError(
+                "Regex flag names must be strings.",
+                details={"rule_id": rule_id},
+            )
+        try:
+            resolved |= getattr(re, flag_name)
+        except AttributeError as exc:
+            raise DataValidationError(
+                "Unsupported regex flag specified for symbol rule.",
+                details={"rule_id": rule_id, "flag": flag_name},
+            ) from exc
+    return resolved
+
+
+def _parse_transform(transform_spec: Any, pattern: re.Pattern[str], rule_id: str) -> RuleTransform:
+    if not isinstance(transform_spec, Mapping):
+        raise DataValidationError(
+            "Symbol rule requires a 'transform' mapping.",
+            details={"rule_id": rule_id},
+        )
+
+    transform_type = transform_spec.get("type")
+    if not isinstance(transform_type, str):
+        raise DataValidationError(
+            "Transform definitions must include a string 'type'.",
+            details={"rule_id": rule_id},
+        )
+
+    if transform_type == "template":
+        return _build_template_transform(transform_spec, pattern, rule_id)
+    if transform_type == "map_template":
+        return _build_map_template_transform(transform_spec, pattern, rule_id)
+
+    raise DataValidationError(
+        "Unsupported transform type for symbol rule.",
+        details={"rule_id": rule_id, "type": transform_type},
+    )
+
+
+def _build_template_transform(transform_spec: Mapping[str, Any], pattern: re.Pattern[str], rule_id: str) -> RuleTransform:
+    template = transform_spec.get("template")
+    if not isinstance(template, str) or not template:
+        raise DataValidationError(
+            "Template transform requires a non-empty 'template' string.",
+            details={"rule_id": rule_id},
+        )
+
+    uppercase = bool(transform_spec.get("uppercase", False))
+    allowed_fields = set(pattern.groupindex.keys()) | {"match"}
+    requested_fields = {field for _, field, _, _ in Formatter().parse(template) if field not in (None, "")}
+    missing = requested_fields - allowed_fields
+    if missing:
+        raise DataValidationError(
+            "Template references unknown regex groups.",
+            details={"rule_id": rule_id, "unknown_fields": sorted(missing)},
+        )
+
+    def _transform(raw_symbol: str, match: re.Match[str]) -> str:
+        context = {key: (value or "") for key, value in match.groupdict().items()}
+        context["match"] = match.group(0)
+        result = template.format_map(_TemplateDict(context))
+        return result.upper() if uppercase else result
+
+    return _transform
+
+
+def _build_map_template_transform(transform_spec: Mapping[str, Any], pattern: re.Pattern[str], rule_id: str) -> RuleTransform:
+    template = transform_spec.get("template")
+    if not isinstance(template, str) or not template:
+        raise DataValidationError(
+            "map_template transform requires a 'template' string.",
+            details={"rule_id": rule_id},
+        )
+
+    group_name = transform_spec.get("group")
+    if not isinstance(group_name, str) or group_name not in pattern.groupindex:
+        raise DataValidationError(
+            "map_template transform requires a valid regex group name.",
+            details={"rule_id": rule_id, "group": group_name},
+        )
+
+    mapping_spec = transform_spec.get("mapping")
+    if not isinstance(mapping_spec, Mapping) or not mapping_spec:
+        raise DataValidationError(
+            "map_template transform requires a non-empty 'mapping' dict.",
+            details={"rule_id": rule_id},
+        )
+
+    case_insensitive = bool(transform_spec.get("case_insensitive", True))
+    normalized_mapping: dict[str, str] = {}
+    for raw_key, mapped_value in mapping_spec.items():
+        if not isinstance(raw_key, str) or not isinstance(mapped_value, str):
+            raise DataValidationError(
+                "Mapping keys and values must be strings.",
+                details={"rule_id": rule_id},
+            )
+        key = raw_key.upper() if case_insensitive else raw_key
+        normalized_mapping[key] = mapped_value
+
+    default_value = transform_spec.get("default")
+    if default_value is not None and not isinstance(default_value, str):
+        raise DataValidationError(
+            "map_template default must be a string or omitted.",
+            details={"rule_id": rule_id},
+        )
+
+    uppercase = bool(transform_spec.get("uppercase", False))
+    allowed_fields = set(pattern.groupindex.keys()) | {"match", "mapped"}
+    requested_fields = {field for _, field, _, _ in Formatter().parse(template) if field not in (None, "")}
+    missing = requested_fields - allowed_fields
+    if missing:
+        raise DataValidationError(
+            "map_template references unknown template fields.",
+            details={"rule_id": rule_id, "unknown_fields": sorted(missing)},
+        )
+
+    def _lookup(original: str) -> str:
+        lookup_key = original.upper() if case_insensitive else original
+        mapped = normalized_mapping.get(lookup_key)
+        if mapped is not None:
+            return mapped
+        if default_value is not None:
+            return default_value.replace("{value}", original)
+        return original
+
+    def _transform(raw_symbol: str, match: re.Match[str]) -> str:
+        context = {key: (value or "") for key, value in match.groupdict().items()}
+        context["match"] = match.group(0)
+        raw_group_value = match.group(group_name) or ""
+        context["mapped"] = _lookup(raw_group_value)
+        result = template.format_map(_TemplateDict(context))
+        return result.upper() if uppercase else result
+
+    return _transform
+
+
+def _parse_market_scope(scope_value: Any, rule_id: str) -> frozenset[MarketType]:
+    if scope_value is None:
+        return frozenset()
+    if not isinstance(scope_value, Iterable) or isinstance(scope_value, str | bytes):
+        raise DataValidationError(
+            "market_scope must be a list of market identifiers.",
+            details={"rule_id": rule_id},
+        )
+
+    markets: list[MarketType] = []
+    for market_name in scope_value:
+        if not isinstance(market_name, str):
+            raise DataValidationError(
+                "market_scope entries must be strings.",
+                details={"rule_id": rule_id},
+            )
+        try:
+            markets.append(MarketType(market_name.lower()))
+        except ValueError as exc:
+            raise DataValidationError(
+                "Unknown market value provided in market_scope.",
+                details={"rule_id": rule_id, "market": market_name},
+            ) from exc
+    return frozenset(markets)
+
+
+def _parse_asset_scope(scope_value: Any, rule_id: str) -> frozenset[AssetType]:
+    if scope_value is None:
+        return frozenset()
+    if not isinstance(scope_value, Iterable) or isinstance(scope_value, str | bytes):
+        raise DataValidationError(
+            "asset_scope must be a list of asset identifiers.",
+            details={"rule_id": rule_id},
+        )
+
+    assets: list[AssetType] = []
+    for asset_name in scope_value:
+        if not isinstance(asset_name, str):
+            raise DataValidationError(
+                "asset_scope entries must be strings.",
+                details={"rule_id": rule_id},
+            )
+        try:
+            assets.append(AssetType(asset_name.lower()))
+        except ValueError as exc:
+            raise DataValidationError(
+                "Unknown asset value provided in asset_scope.",
+                details={"rule_id": rule_id, "asset": asset_name},
+            ) from exc
+    return frozenset(assets)
+
+
+__all__ = ["load_symbol_rules", "load_symbol_rules_from_mapping"]

--- a/vprism/core/services/symbols.py
+++ b/vprism/core/services/symbols.py
@@ -1,0 +1,412 @@
+"""Core symbol normalization service with in-memory caching, diagnostics, and persistence."""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict, defaultdict
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from vprism.core.data.schema import SYMBOL_MAP_TABLE
+from vprism.core.exceptions.base import UnresolvedSymbolError
+from vprism.core.models.market import AssetType, MarketType
+from vprism.core.models.symbols import (
+    BatchNormalizationItem,
+    BatchNormalizationResult,
+    CanonicalSymbol,
+    RuleTransform,
+    SymbolRule,
+)
+
+if TYPE_CHECKING:
+    from duckdb import DuckDBPyConnection
+
+CacheKey = tuple[str, MarketType, AssetType]
+
+
+_CN_SUFFIX_EXCHANGE_MAP: Mapping[str, str] = {"SS": "SH", "SH": "SH", "SZ": "SZ"}
+_CN_PREFIX_EXCHANGE_MAP: Mapping[str, str] = {"SH": "SH", "SZ": "SZ"}
+_FUND_SUFFIX_EXCHANGE_MAP: Mapping[str, str] = {
+    "OF": "OF",
+    "SZ": "SZ",
+    "SH": "SH",
+}
+_FUND_PREFIX_EXCHANGE_MAP: Mapping[str, str] = {
+    "OF": "OF",
+    "SZ": "SZ",
+    "SH": "SH",
+}
+
+
+def _exchange_from_mapping(token: str, mapping: Mapping[str, str]) -> str:
+    normalized = token.upper()
+    return mapping.get(normalized, normalized)
+
+
+def _suffix_rule(mapping: Mapping[str, str]) -> RuleTransform:
+    def _transform(raw: str, match: re.Match[str]) -> str:
+        code = match.group("code")
+        suffix = match.group("suffix")
+        exchange = _exchange_from_mapping(suffix, mapping)
+        return f"{exchange}{code}"
+
+    return _transform
+
+
+def _prefix_rule(mapping: Mapping[str, str]) -> RuleTransform:
+    def _transform(raw: str, match: re.Match[str]) -> str:
+        prefix = match.group("prefix")
+        code = match.group("code")
+        exchange = _exchange_from_mapping(prefix, mapping)
+        return f"{exchange}{code}"
+
+    return _transform
+
+
+def _numeric_rule() -> RuleTransform:
+    def _transform(raw: str, match: re.Match[str]) -> str:
+        return match.group("code")
+
+    return _transform
+
+
+def _uppercase_token_rule() -> RuleTransform:
+    def _transform(raw: str, match: re.Match[str]) -> str:
+        return match.group("token").upper()
+
+    return _transform
+
+
+def _build_cn_stock_rules() -> list[SymbolRule]:
+    return [
+        SymbolRule(
+            id="cn_stock_yfinance",
+            priority=10,
+            pattern=re.compile(r"^(?P<code>\d{6})\.(?P<suffix>SS|SH|SZ)$", re.IGNORECASE),
+            transform=_suffix_rule(_CN_SUFFIX_EXCHANGE_MAP),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.STOCK}),
+        ),
+        SymbolRule(
+            id="cn_stock_akshare",
+            priority=15,
+            pattern=re.compile(r"^(?P<prefix>sh|sz)(?P<code>\d{6})$", re.IGNORECASE),
+            transform=_prefix_rule(_CN_PREFIX_EXCHANGE_MAP),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.STOCK}),
+        ),
+        SymbolRule(
+            id="cn_stock_numeric",
+            priority=20,
+            pattern=re.compile(r"^(?P<code>\d{6})$"),
+            transform=_numeric_rule(),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.STOCK}),
+        ),
+    ]
+
+
+def _build_cn_fund_rules() -> list[SymbolRule]:
+    return [
+        SymbolRule(
+            id="cn_fund_yfinance",
+            priority=30,
+            pattern=re.compile(r"^(?P<code>\d{6})\.(?P<suffix>OF|SZ|SH)$", re.IGNORECASE),
+            transform=_suffix_rule(_FUND_SUFFIX_EXCHANGE_MAP),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.FUND}),
+        ),
+        SymbolRule(
+            id="cn_fund_akshare",
+            priority=35,
+            pattern=re.compile(r"^(?P<prefix>of|sz|sh)(?P<code>\d{6})$", re.IGNORECASE),
+            transform=_prefix_rule(_FUND_PREFIX_EXCHANGE_MAP),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.FUND}),
+        ),
+        SymbolRule(
+            id="cn_fund_numeric",
+            priority=40,
+            pattern=re.compile(r"^(?P<code>\d{6})$"),
+            transform=_numeric_rule(),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.FUND}),
+        ),
+    ]
+
+
+def _build_cn_index_rules() -> list[SymbolRule]:
+    return [
+        SymbolRule(
+            id="cn_index_yfinance",
+            priority=50,
+            pattern=re.compile(r"^(?P<code>\d{6})\.(?P<suffix>SH|SZ)$", re.IGNORECASE),
+            transform=_suffix_rule(_CN_SUFFIX_EXCHANGE_MAP),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.INDEX}),
+        ),
+        SymbolRule(
+            id="cn_index_akshare",
+            priority=55,
+            pattern=re.compile(r"^(?P<prefix>sh|sz)(?P<code>\d{6})$", re.IGNORECASE),
+            transform=_prefix_rule(_CN_PREFIX_EXCHANGE_MAP),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.INDEX}),
+        ),
+        SymbolRule(
+            id="cn_index_numeric",
+            priority=60,
+            pattern=re.compile(r"^(?P<code>\d{6})$"),
+            transform=_numeric_rule(),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.INDEX}),
+        ),
+    ]
+
+
+@lru_cache(maxsize=1)
+def default_rules() -> tuple[SymbolRule, ...]:
+    rules: list[SymbolRule] = []
+    rules.extend(_build_cn_stock_rules())
+    rules.extend(_build_cn_fund_rules())
+    rules.extend(_build_cn_index_rules())
+    rules.append(
+        SymbolRule(
+            id="generic_uppercase",
+            priority=1000,
+            pattern=re.compile(r"^(?P<token>[A-Z]{1,10})$", re.IGNORECASE),
+            transform=_uppercase_token_rule(),
+        )
+    )
+    return tuple(sorted(rules, key=lambda rule: (rule.priority, rule.id)))
+
+
+class SymbolService:
+    """Provides canonical symbol normalization using priority-ordered rules."""
+
+    def __init__(
+        self,
+        rules: Sequence[SymbolRule] | None = None,
+        cache_size: int = 10_000,
+        persistence_conn: DuckDBPyConnection | None = None,
+    ) -> None:
+        self._cache_size = max(cache_size, 0)
+        resolved_rules = rules if rules is not None else default_rules()
+        self._rules: tuple[SymbolRule, ...] = tuple(sorted(resolved_rules, key=lambda rule: (rule.priority, rule.id)))
+        self._cache: OrderedDict[CacheKey, CanonicalSymbol] = OrderedDict()
+        self._metrics: dict[str, object] = {
+            "total_requests": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "unresolved_count": 0,
+            "rule_usage": defaultdict(int),
+        }
+        self._persistence_conn = persistence_conn
+        if self._persistence_conn is not None:
+            SYMBOL_MAP_TABLE.ensure(self._persistence_conn)
+
+    @property
+    def rules(self) -> tuple[SymbolRule, ...]:
+        """Return the rules currently registered with the service."""
+
+        return self._rules
+
+    def normalize(
+        self,
+        raw_symbol: str,
+        market: MarketType,
+        asset_type: AssetType,
+        provider_hint: str | None = None,
+    ) -> CanonicalSymbol:
+        """Normalize a raw symbol into its canonical representation."""
+
+        normalized_raw = raw_symbol.strip()
+        cache_key: CacheKey = (normalized_raw, market, asset_type)
+        self._metrics["total_requests"] = int(self._metrics["total_requests"]) + 1
+
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            self._metrics["cache_hits"] = int(self._metrics["cache_hits"]) + 1
+            return cached
+
+        self._metrics["cache_misses"] = int(self._metrics["cache_misses"]) + 1
+        canonical = self._evaluate_rules(normalized_raw, market, asset_type)
+        self._persist_normalization(canonical, provider_hint)
+        self._cache_set(cache_key, canonical)
+        return canonical
+
+    def normalize_batch(
+        self,
+        raw_symbols: Sequence[str],
+        market: MarketType,
+        asset_type: AssetType,
+        provider_hint: str | Mapping[str, str] | None = None,
+    ) -> BatchNormalizationResult:
+        """Normalize a sequence of raw symbols with partial success reporting."""
+
+        items: list[BatchNormalizationItem] = []
+        successes: list[CanonicalSymbol] = []
+        failures: list[UnresolvedSymbolError] = []
+
+        for raw_symbol in raw_symbols:
+            normalized_input = raw_symbol.strip()
+            hint_value: str | None
+            if isinstance(provider_hint, Mapping):
+                hint_value = provider_hint.get(normalized_input)
+                if hint_value is None and normalized_input != raw_symbol:
+                    hint_value = provider_hint.get(raw_symbol)
+            else:
+                hint_value = provider_hint
+
+            try:
+                canonical = self.normalize(
+                    normalized_input, market, asset_type, provider_hint=hint_value
+                )
+            except UnresolvedSymbolError as error:
+                items.append(
+                    BatchNormalizationItem(
+                        raw_symbol=normalized_input,
+                        status="unresolved",
+                        error=error,
+                    )
+                )
+                failures.append(error)
+            else:
+                items.append(
+                    BatchNormalizationItem(
+                        raw_symbol=normalized_input,
+                        status="resolved",
+                        canonical=canonical,
+                    )
+                )
+                successes.append(canonical)
+
+        return BatchNormalizationResult(
+            market=market,
+            asset_type=asset_type,
+            items=tuple(items),
+            successes=tuple(successes),
+            failures=tuple(failures),
+        )
+
+    def get_metrics(self) -> Mapping[str, object]:
+        """Return a snapshot of cache and normalization metrics."""
+
+        total_requests = int(self._metrics["total_requests"])
+        cache_hits = int(self._metrics["cache_hits"])
+        cache_misses = int(self._metrics["cache_misses"])
+        unresolved_count = int(self._metrics["unresolved_count"])
+        hit_rate = cache_hits / total_requests if total_requests else 0.0
+        rule_usage = dict(self._metrics["rule_usage"])
+        return {
+            "total_requests": total_requests,
+            "cache_hits": cache_hits,
+            "cache_misses": cache_misses,
+            "unresolved_count": unresolved_count,
+            "hit_rate": hit_rate,
+            "rule_usage": rule_usage,
+        }
+
+    def reload(self, new_rules: Sequence[SymbolRule]) -> None:
+        """Atomically replace the rule set and clear derived caches."""
+
+        if not new_rules:
+            raise ValueError("SymbolService requires at least one rule for reload().")
+        if not all(isinstance(rule, SymbolRule) for rule in new_rules):
+            raise TypeError("All rules supplied to reload() must be SymbolRule instances.")
+
+        self._rules = tuple(sorted(new_rules, key=lambda rule: (rule.priority, rule.id)))
+        self._cache.clear()
+        self._metrics["rule_usage"] = defaultdict(int)
+
+    def _evaluate_rules(
+        self,
+        raw_symbol: str,
+        market: MarketType,
+        asset_type: AssetType,
+    ) -> CanonicalSymbol:
+        for rule in self._rules:
+            if not rule.applies_to(market, asset_type):
+                continue
+            match = rule.pattern.match(raw_symbol)
+            if not match:
+                continue
+            core_value = rule.transform(raw_symbol, match)
+            if rule.prefix:
+                core_value = f"{rule.prefix}{core_value}"
+            if rule.suffix:
+                core_value = f"{core_value}{rule.suffix}"
+            canonical_value = self._compose_canonical(market, asset_type, core_value)
+            canonical = CanonicalSymbol(
+                raw_symbol=raw_symbol,
+                canonical=canonical_value,
+                market=market,
+                asset_type=asset_type,
+                rule_id=rule.id,
+            )
+            self._metrics["rule_usage"][rule.id] += 1
+            return canonical
+
+        self._metrics["unresolved_count"] = int(self._metrics["unresolved_count"]) + 1
+        raise UnresolvedSymbolError(
+            message=(f"Unable to normalize symbol '{raw_symbol}' for market '{market.value}' and asset '{asset_type.value}'."),
+            raw_symbol=raw_symbol,
+            market=market.value,
+            asset_type=asset_type.value,
+            details={"rules_evaluated": [rule.id for rule in self._rules]},
+        )
+
+    def _compose_canonical(self, market: MarketType, asset_type: AssetType, core_value: str) -> str:
+        market_prefix = market.value.upper()
+        asset_segment = asset_type.value.upper()
+        return f"{market_prefix}:{asset_segment}:{core_value}"
+
+    def _cache_get(self, key: CacheKey) -> CanonicalSymbol | None:
+        try:
+            cached = self._cache[key]
+        except KeyError:
+            return None
+        self._cache.move_to_end(key)
+        return cached
+
+    def _cache_set(self, key: CacheKey, value: CanonicalSymbol) -> None:
+        if self._cache_size == 0:
+            return
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = value
+        if len(self._cache) > self._cache_size:
+            self._cache.popitem(last=False)
+
+    def _persist_normalization(self, canonical: CanonicalSymbol, provider_hint: str | None) -> None:
+        if self._persistence_conn is None:
+            return
+
+        self._persistence_conn.execute(
+            """
+            INSERT OR IGNORE INTO symbol_map (
+                c_symbol,
+                raw_symbol,
+                market,
+                asset_type,
+                provider_hint,
+                rule_id,
+                created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                canonical.canonical,
+                canonical.raw_symbol,
+                canonical.market.value,
+                canonical.asset_type.value,
+                provider_hint,
+                canonical.rule_id,
+                datetime.now(datetime.UTC),
+            ],
+        )
+
+
+__all__ = ["SymbolService", "default_rules"]

--- a/vprism/core/validation/__init__.py
+++ b/vprism/core/validation/__init__.py
@@ -2,10 +2,18 @@
 
 from vprism.core.validation.consistency import ConsistencyReport, DataConsistencyValidator
 from vprism.core.validation.quality import DataQualityScorer, DataQualityValidator
+from vprism.core.validation.schema_assertions import (
+    assert_baseline_tables,
+    assert_table_matches_schema,
+    assert_tables_match_schemas,
+)
 
 __all__ = [
     "DataQualityValidator",
     "DataQualityScorer",
     "ConsistencyReport",
     "DataConsistencyValidator",
+    "assert_table_matches_schema",
+    "assert_tables_match_schemas",
+    "assert_baseline_tables",
 ]

--- a/vprism/core/validation/schema_assertions.py
+++ b/vprism/core/validation/schema_assertions.py
@@ -1,0 +1,127 @@
+"""DuckDB schema validation helpers for PRD-0 baseline datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+try:  # pragma: no cover - duckdb optional for type checking environments.
+    from duckdb import DuckDBPyConnection
+except Exception:  # pragma: no cover
+    DuckDBPyConnection = "DuckDBPyConnection"  # type: ignore[misc,assignment]
+
+from vprism.core.data.schema import ColumnDef, TableSchema, baseline_tables
+from vprism.core.exceptions.base import DataValidationError
+
+
+@dataclass(frozen=True)
+class _ObservedColumn:
+    """Represents DuckDB column metadata from PRAGMA table_info."""
+
+    name: str
+    data_type: str
+    not_null: bool
+
+
+def _fetch_table_info(conn: DuckDBPyConnection, table_name: str) -> dict[str, _ObservedColumn]:
+    """Return DuckDB column metadata keyed by column name."""
+
+    pragma_sql = f"PRAGMA table_info('{table_name}')"
+    rows = conn.execute(pragma_sql).fetchall()
+    columns: dict[str, _ObservedColumn] = {}
+    for row in rows:
+        # DuckDB PRAGMA table_info rows: (cid, name, type, notnull, dflt_value, pk)
+        _, name, data_type, notnull, _, _ = row
+        columns[name] = _ObservedColumn(name=name, data_type=str(data_type).upper(), not_null=bool(notnull))
+    return columns
+
+
+def _constraint_flags(column: ColumnDef) -> Mapping[str, bool]:
+    """Return constraint flags derived from a :class:`ColumnDef`."""
+
+    constraints = {constraint.upper() for constraint in column.constraints}
+    return {"not_null": "NOT NULL" in constraints}
+
+
+def _normalize_type(data_type: str) -> str:
+    """Normalize DuckDB type strings for comparison."""
+
+    return data_type.strip().upper()
+
+
+def assert_table_matches_schema(conn: DuckDBPyConnection, expected: TableSchema) -> None:
+    """Assert that a DuckDB table matches the provided :class:`TableSchema`.
+
+    Args:
+        conn: Active DuckDB connection to inspect.
+        expected: TableSchema describing the desired structure.
+
+    Raises:
+        DataValidationError: Raised when the table is missing, lacks required columns,
+            or column types/constraints differ from the expected definition.
+    """
+
+    observed_columns = _fetch_table_info(conn, expected.name)
+    if not observed_columns:
+        raise DataValidationError(
+            message=f"DuckDB table '{expected.name}' does not exist.",
+            validation_errors={"table_missing": True},
+            details={"table": expected.name},
+        )
+
+    missing_columns: list[str] = []
+    type_mismatches: dict[str, dict[str, str]] = {}
+    constraint_mismatches: dict[str, dict[str, bool]] = {}
+
+    for column in expected.columns:
+        observed = observed_columns.get(column.name)
+        if observed is None:
+            missing_columns.append(column.name)
+            continue
+
+        expected_type = _normalize_type(column.data_type)
+        actual_type = _normalize_type(observed.data_type)
+        if expected_type != actual_type:
+            type_mismatches[column.name] = {
+                "expected": expected_type,
+                "actual": actual_type,
+            }
+
+        expected_constraints = _constraint_flags(column)
+        actual_constraints = {"not_null": observed.not_null}
+        if expected_constraints != actual_constraints:
+            constraint_mismatches[column.name] = {
+                "expected_not_null": expected_constraints["not_null"],
+                "actual_not_null": actual_constraints["not_null"],
+            }
+
+    if missing_columns or type_mismatches or constraint_mismatches:
+        raise DataValidationError(
+            message=f"DuckDB table '{expected.name}' does not match expected schema.",
+            validation_errors={
+                "missing_columns": missing_columns,
+                "type_mismatches": type_mismatches,
+                "constraint_mismatches": constraint_mismatches,
+            },
+            details={"table": expected.name},
+        )
+
+
+def assert_tables_match_schemas(conn: DuckDBPyConnection, schemas: Iterable[TableSchema]) -> None:
+    """Assert that multiple DuckDB tables match their expected schemas."""
+
+    for schema in schemas:
+        assert_table_matches_schema(conn, schema)
+
+
+def assert_baseline_tables(conn: DuckDBPyConnection) -> None:
+    """Assert that all PRD-0 baseline tables exist with the expected schemas."""
+
+    assert_tables_match_schemas(conn, baseline_tables())
+
+
+__all__ = [
+    "assert_table_matches_schema",
+    "assert_tables_match_schemas",
+    "assert_baseline_tables",
+]


### PR DESCRIPTION
## Summary
- add DuckDB schemas and helpers for corporate_actions and adjustments tables with tests
- implement the AdjustmentEngine compute pipeline with factor generation, hashing, and gap detection plus supporting models and exception
- cover schema creation and adjustment workflows with targeted pytest suites

## Testing
- uv run pytest tests/core/data/test_corporate_action_schema.py tests/core/services/test_adjustment_engine.py
- uv run ruff check vprism/core/data/schema.py vprism/core/models/corporate_actions.py vprism/core/services/adjustment_engine.py tests/core/data/test_corporate_action_schema.py tests/core/services/test_adjustment_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68cb701f79b4832da3e900b0844b225d