### PR TITLE
Add gap detector quality metrics service

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 29,
+      "todo": 27,
       "in_progress": 0,
-      "done": 24,
+      "done": 26,
       "prd_count": 10
     },
     "tasks": [
@@ -652,7 +652,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove merge and caching enhancements and tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Corporate action merge utilities and factor caching implemented via AdjustmentEngine with coverage in pytest tests/core/services/test_adjustment_merge.py"
       },
       {
         "id": "PRD-3-004",
@@ -770,7 +771,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove gap detector implementation and tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "GapDetector computes gap_ratio with calendar-backed expectations and persists metrics using DuckDBQualityMetricWriter; verified by pytest tests/core/services/quality/test_gap_detector.py"
       },
       {
         "id": "PRD-4-004",

--- a/tests/core/services/quality/test_gap_detector.py
+++ b/tests/core/services/quality/test_gap_detector.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import duckdb
+import pytest
+
+from vprism.core.data.schema import VPrismQualityMetricStatus, vprism_quality_metrics_table
+from vprism.core.services.calendars import VPrismTradingCalendarProvider
+from vprism.core.services.quality.gap_detector import (
+    DEFAULT_GAP_RATIO_THRESHOLDS,
+    DuckDBQualityMetricWriter,
+    GapDetector,
+)
+
+
+@pytest.fixture()
+def duckdb_connection() -> duckdb.DuckDBPyConnection:
+    connection = duckdb.connect(database=":memory:")
+    vprism_quality_metrics_table.ensure(connection)
+    return connection
+
+
+def _fixed_clock() -> datetime:
+    return datetime(2024, 1, 6, 12, tzinfo=UTC)
+
+
+def test_gap_detector_records_ok_metric(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    provider = VPrismTradingCalendarProvider()
+    detector = GapDetector(
+        provider,
+        DuckDBQualityMetricWriter(duckdb_connection),
+        clock=_fixed_clock,
+    )
+
+    observed = [
+        datetime(2024, 1, 1, 10, tzinfo=UTC),
+        datetime(2024, 1, 2, 10, tzinfo=UTC),
+        datetime(2024, 1, 3, 10, tzinfo=UTC),
+        datetime(2024, 1, 4, 10, tzinfo=UTC),
+        datetime(2024, 1, 5, 10, tzinfo=UTC),
+    ]
+
+    result = detector.evaluate(
+        market="cn",
+        symbol="000001",
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 5),
+        observed_timestamps=observed,
+        run_id="run-ok",
+    )
+
+    assert result.gap_ratio == pytest.approx(0.0)
+    assert result.status is VPrismQualityMetricStatus.OK
+    assert result.missing_days == ()
+
+    row = duckdb_connection.execute(
+        """
+        SELECT date, market, supplier_symbol, metric, value, status, run_id, created_at
+        FROM quality_metrics
+        """
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == date(2024, 1, 5)
+    assert row[1] == "cn"
+    assert row[2] == "000001"
+    assert row[3] == "gap_ratio"
+    assert row[4] == pytest.approx(0.0)
+    assert row[5] == "OK"
+    assert row[6] == "run-ok"
+    stored_created_at = row[7]
+    if stored_created_at.tzinfo is None:
+        stored_created_at = stored_created_at.replace(tzinfo=UTC)
+    assert stored_created_at == _fixed_clock()
+
+
+def test_gap_detector_records_fail_when_missing_days(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    provider = VPrismTradingCalendarProvider()
+    detector = GapDetector(
+        provider,
+        DuckDBQualityMetricWriter(duckdb_connection),
+        gap_thresholds=DEFAULT_GAP_RATIO_THRESHOLDS,
+        clock=_fixed_clock,
+    )
+
+    observed = [
+        date(2024, 1, 1),
+        date(2024, 1, 3),
+        date(2024, 1, 5),
+    ]
+
+    result = detector.evaluate(
+        market="cn",
+        symbol="000002",
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 5),
+        observed_timestamps=observed,
+        run_id="run-fail",
+    )
+
+    assert result.missing_days == (date(2024, 1, 2), date(2024, 1, 4))
+    assert result.gap_ratio == pytest.approx(2 / 5)
+    assert result.status is VPrismQualityMetricStatus.FAIL
+
+    row = duckdb_connection.execute(
+        """
+        SELECT metric, value, status, run_id
+        FROM quality_metrics
+        WHERE supplier_symbol = ?
+        """,
+        ["000002"],
+    ).fetchone()
+
+    assert row[0] == "gap_ratio"
+    assert row[1] == pytest.approx(2 / 5)
+    assert row[2] == "FAIL"
+    assert row[3] == "run-fail"

--- a/vprism/core/services/quality/__init__.py
+++ b/vprism/core/services/quality/__init__.py
@@ -1,5 +1,18 @@
 """vprism data quality service utilities."""
 
+from vprism.core.services.quality.gap_detector import (
+    DEFAULT_GAP_RATIO_THRESHOLDS,
+    DuckDBQualityMetricWriter,
+    GapDetectionResult,
+    GapDetector,
+    QualityMetricRow,
+)
+
 __all__ = [
+    "DEFAULT_GAP_RATIO_THRESHOLDS",
+    "DuckDBQualityMetricWriter",
+    "GapDetectionResult",
+    "GapDetector",
+    "QualityMetricRow",
     "thresholds",
 ]

--- a/vprism/core/services/quality/gap_detector.py
+++ b/vprism/core/services/quality/gap_detector.py
@@ -1,0 +1,165 @@
+"""Gap detection service writing metrics into the quality schema."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+from vprism.core.data.schema import (
+    VPrismQualityMetricStatus,
+    vprism_quality_metrics_table,
+)
+from vprism.core.services.quality.thresholds import (
+    VPrismMetricThresholds,
+    vprism_classify_metric,
+)
+
+GapMetricWriter = Callable[["QualityMetricRow"], None]
+
+if TYPE_CHECKING:
+    from duckdb import DuckDBPyConnection
+
+    from vprism.core.services.calendars import VPrismTradingCalendarProvider
+
+
+@dataclass(frozen=True)
+class QualityMetricRow:
+    """Row persisted into the ``quality_metrics`` table."""
+
+    date: date
+    market: str
+    supplier_symbol: str
+    metric: str
+    value: float
+    status: VPrismQualityMetricStatus
+    run_id: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class GapDetectionResult:
+    """Computed gap metrics for the supplied time window."""
+
+    expected_days: tuple[date, ...]
+    observed_days: tuple[date, ...]
+    missing_days: tuple[date, ...]
+    gap_ratio: float
+    status: VPrismQualityMetricStatus
+
+
+DEFAULT_GAP_RATIO_THRESHOLDS = VPrismMetricThresholds(warn=0.002, fail=0.005)
+
+
+class GapDetector:
+    """Detects missing trading days and records gap metrics."""
+
+    def __init__(
+        self,
+        calendar_provider: VPrismTradingCalendarProvider,
+        metric_writer: GapMetricWriter,
+        gap_thresholds: VPrismMetricThresholds | None = None,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._calendar_provider = calendar_provider
+        self._metric_writer = metric_writer
+        self._thresholds = gap_thresholds or DEFAULT_GAP_RATIO_THRESHOLDS
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def evaluate(
+        self,
+        *,
+        market: str,
+        symbol: str,
+        start: date,
+        end: date,
+        observed_timestamps: Sequence[date | datetime] | Iterable[date | datetime],
+        run_id: str,
+        metric_date: date | None = None,
+    ) -> GapDetectionResult:
+        """Compute gap metrics for the provided parameters and persist them."""
+
+        expected_days = tuple(self._calendar_provider.vprism_get_trading_days(market, start, end))
+        observed_days = self._normalize_observed(observed_timestamps, start, end)
+        missing_days = tuple(day for day in expected_days if day not in observed_days)
+
+        gap_ratio = self._compute_gap_ratio(len(expected_days), len(missing_days))
+        status = vprism_classify_metric(gap_ratio, self._thresholds)
+
+        created_at = self._clock()
+        metric_row = QualityMetricRow(
+            date=metric_date or end,
+            market=market,
+            supplier_symbol=symbol,
+            metric="gap_ratio",
+            value=gap_ratio,
+            status=status,
+            run_id=run_id,
+            created_at=created_at,
+        )
+        self._metric_writer(metric_row)
+
+        return GapDetectionResult(
+            expected_days=expected_days,
+            observed_days=tuple(sorted(observed_days)),
+            missing_days=missing_days,
+            gap_ratio=gap_ratio,
+            status=status,
+        )
+
+    @staticmethod
+    def _normalize_observed(
+        timestamps: Sequence[date | datetime] | Iterable[date | datetime],
+        start: date,
+        end: date,
+    ) -> set[date]:
+        observed: set[date] = set()
+        for value in timestamps:
+            current_date = value.date() if isinstance(value, datetime) else value
+            if start <= current_date <= end:
+                observed.add(current_date)
+        return observed
+
+    @staticmethod
+    def _compute_gap_ratio(expected_count: int, missing_count: int) -> float:
+        if expected_count == 0:
+            return 0.0
+        return missing_count / expected_count
+
+
+class DuckDBQualityMetricWriter:
+    """Persist quality metric rows into DuckDB."""
+
+    def __init__(self, connection: DuckDBPyConnection) -> None:
+        self._connection = connection
+        vprism_quality_metrics_table.ensure(connection)
+
+    def __call__(self, row: QualityMetricRow) -> None:
+        self._connection.execute(
+            """
+            INSERT INTO quality_metrics
+            (date, market, supplier_symbol, metric, value, status, run_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                row.date,
+                row.market,
+                row.supplier_symbol,
+                row.metric,
+                row.value,
+                row.status.value,
+                row.run_id,
+                row.created_at,
+            ],
+        )
+
+
+__all__ = [
+    "DEFAULT_GAP_RATIO_THRESHOLDS",
+    "DuckDBQualityMetricWriter",
+    "GapDetectionResult",
+    "GapDetector",
+    "QualityMetricRow",
+]


### PR DESCRIPTION
## Summary
- add a GapDetector service that computes gap ratios and persists metrics through a DuckDB writer
- cover the detector with targeted pytest scenarios for complete and missing trading days
- update the PRD plan to mark corporate action merge caching and gap detector tasks as completed

## Testing
- uv run pytest tests/core/services/quality/test_gap_detector.py
- uv run ruff check vprism/core/services/quality/gap_detector.py tests/core/services/quality/test_gap_detector.py

------
https://chatgpt.com/codex/tasks/task_e_68d50f5cd4f0832d9eec3946146cbebc