### PR TITLE
Implement adjustment persistence and duplicate detector

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 27,
+      "todo": 25,
       "in_progress": 0,
-      "done": 26,
+      "done": 28,
       "prd_count": 10
     },
     "tasks": [
@@ -677,7 +677,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove persistence step and adjust tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "AdjustmentEngine now persists factor rows via DuckDB writer with deterministic timestamps; validated by pytest tests/core/services/test_adjustment_persistence.py"
       },
       {
         "id": "PRD-4-001",
@@ -796,7 +797,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove duplicate detector logic and tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Duplicate detector aggregates duplicate_count metrics with threshold classification and writes quality_metrics rows; covered by pytest tests/core/services/quality/test_duplicate_detector.py"
       },
       {
         "id": "PRD-4-005",

--- a/tests/core/services/quality/test_duplicate_detector.py
+++ b/tests/core/services/quality/test_duplicate_detector.py
@@ -1,0 +1,112 @@
+import duckdb
+import pytest
+
+from datetime import UTC, date, datetime
+
+from vprism.core.data.schema import vprism_quality_metrics_table
+from vprism.core.services.quality.duplicate_detector import (
+    DEFAULT_DUPLICATE_THRESHOLDS,
+    VPrismDuplicateDetector,
+)
+from vprism.core.services.quality.gap_detector import DuckDBQualityMetricWriter
+from vprism.core.data.schema import VPrismQualityMetricStatus
+
+
+@pytest.fixture()
+def duckdb_connection() -> duckdb.DuckDBPyConnection:
+    connection = duckdb.connect(database=":memory:")
+    vprism_quality_metrics_table.ensure(connection)
+    return connection
+
+
+def _fixed_clock() -> datetime:
+    return datetime(2024, 3, 1, 9, tzinfo=UTC)
+
+
+def test_duplicate_detector_records_fail_metric(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    detector = VPrismDuplicateDetector(
+        DuckDBQualityMetricWriter(duckdb_connection),
+        DEFAULT_DUPLICATE_THRESHOLDS,
+        clock=_fixed_clock,
+    )
+    observed = [
+        datetime(2024, 1, 1, 9, tzinfo=UTC),
+        datetime(2024, 1, 1, 10, tzinfo=UTC),
+        datetime(2024, 1, 2, 9, tzinfo=UTC),
+        datetime(2024, 1, 2, 10, tzinfo=UTC),
+        datetime(2024, 1, 2, 11, tzinfo=UTC),
+    ]
+
+    result = detector.evaluate(
+        market="cn",
+        symbol="000001",
+        observed_timestamps=observed,
+        run_id="run-duplicates",
+        metric_date=date(2024, 1, 2),
+    )
+
+    assert result.duplicate_total == 3
+    assert result.status is VPrismQualityMetricStatus.FAIL
+    assert result.duplicates == (
+        (date(2024, 1, 1), 2),
+        (date(2024, 1, 2), 3),
+    )
+
+    row = duckdb_connection.execute(
+        """
+        SELECT value, status, run_id, created_at
+        FROM quality_metrics
+        WHERE metric = 'duplicate_count'
+        """
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == pytest.approx(3.0)
+    assert row[1] == "FAIL"
+    assert row[2] == "run-duplicates"
+    stored_time = row[3]
+    if stored_time.tzinfo is None:
+        stored_time = stored_time.replace(tzinfo=UTC)
+    assert stored_time == _fixed_clock()
+
+
+def test_duplicate_detector_records_ok_metric_when_unique(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    detector = VPrismDuplicateDetector(
+        DuckDBQualityMetricWriter(duckdb_connection),
+        clock=_fixed_clock,
+    )
+    observed = [
+        date(2024, 1, 1),
+        date(2024, 1, 2),
+        date(2024, 1, 3),
+    ]
+
+    result = detector.evaluate(
+        market="cn",
+        symbol="000002",
+        observed_timestamps=observed,
+        run_id="run-unique",
+        metric_date=date(2024, 1, 3),
+    )
+
+    assert result.duplicate_total == 0
+    assert result.status is VPrismQualityMetricStatus.OK
+    assert result.duplicates == ()
+
+    row = duckdb_connection.execute(
+        """
+        SELECT value, status, run_id
+        FROM quality_metrics
+        WHERE supplier_symbol = ?
+        """,
+        ["000002"],
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == pytest.approx(0.0)
+    assert row[1] == "OK"
+    assert row[2] == "run-unique"

--- a/tests/core/services/test_adjustment_persistence.py
+++ b/tests/core/services/test_adjustment_persistence.py
@@ -1,0 +1,105 @@
+import duckdb
+import pytest
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from vprism.core.data.schema import ADJUSTMENTS_TABLE
+from vprism.core.models.base import DataPoint
+from vprism.core.models.corporate_actions import CorporateActionSet
+from vprism.core.models.market import MarketType
+from vprism.core.models.query import Adjustment
+from vprism.core.services.adjustment_engine import (
+    AdjustmentEngine,
+    VPrismDuckDBAdjustmentWriter,
+)
+
+
+def _point(day: date, close: str) -> DataPoint:
+    return DataPoint(
+        symbol="000001",
+        market=MarketType.CN,
+        timestamp=datetime.combine(day, datetime.min.time(), tzinfo=UTC),
+        close_price=Decimal(close),
+        provider="test",
+    )
+
+
+def _loader(points: list[DataPoint]):
+    def _inner(symbol: str, market: MarketType, start: date, end: date) -> list[DataPoint]:
+        return list(points)
+
+    return _inner
+
+
+def _actions() -> CorporateActionSet:
+    return CorporateActionSet(dividends=(), splits=())
+
+
+@pytest.fixture()
+def duckdb_connection() -> duckdb.DuckDBPyConnection:
+    connection = duckdb.connect(database=":memory:")
+    ADJUSTMENTS_TABLE.ensure(connection)
+    return connection
+
+
+def _fixed_clock() -> datetime:
+    return datetime(2024, 2, 1, 12, tzinfo=UTC)
+
+
+def test_adjustment_engine_persists_rows(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    points = [
+        _point(date(2024, 1, 1), "10"),
+        _point(date(2024, 1, 2), "10"),
+    ]
+    engine = AdjustmentEngine(
+        _loader(points),
+        lambda symbol, market, start, end: _actions(),
+        factor_writer=VPrismDuckDBAdjustmentWriter(duckdb_connection),
+        clock=_fixed_clock,
+    )
+
+    result = engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 2), Adjustment.FORWARD)
+
+    stored = duckdb_connection.execute(
+        """
+        SELECT market, supplier_symbol, date, adj_factor_qfq, adj_factor_hfq, version, build_time, source_events_hash
+        FROM adjustments
+        ORDER BY date
+        """
+    ).fetchall()
+
+    assert len(stored) == len(result.rows)
+    assert {row.date for row in result.rows} == {entry[2] for entry in stored}
+    for entry in stored:
+        assert entry[0] == "cn"
+        assert entry[1] == "000001"
+        assert entry[5] == result.version
+        assert entry[7] == result.source_events_hash
+
+    stored_time = stored[0][6]
+    if stored_time.tzinfo is None:
+        stored_time = stored_time.replace(tzinfo=UTC)
+    assert stored_time == _fixed_clock()
+
+
+def test_adjustment_engine_replaces_existing_rows(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    points = [
+        _point(date(2024, 1, 1), "10"),
+    ]
+    engine = AdjustmentEngine(
+        _loader(points),
+        lambda symbol, market, start, end: _actions(),
+        factor_writer=VPrismDuckDBAdjustmentWriter(duckdb_connection),
+        clock=_fixed_clock,
+    )
+
+    engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 1), Adjustment.NONE)
+    engine.compute("000001", MarketType.CN, date(2024, 1, 1), date(2024, 1, 1), Adjustment.NONE)
+
+    stored = duckdb_connection.execute("SELECT COUNT(*) FROM adjustments").fetchone()[0]
+    assert stored == 1

--- a/vprism/core/services/quality/duplicate_detector.py
+++ b/vprism/core/services/quality/duplicate_detector.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+from vprism.core.data.schema import VPrismQualityMetricStatus
+from vprism.core.services.quality.gap_detector import QualityMetricRow
+from vprism.core.services.quality.thresholds import (
+    VPrismMetricThresholds,
+    vprism_classify_metric,
+)
+
+if TYPE_CHECKING:
+    from duckdb import DuckDBPyConnection
+
+    from vprism.core.services.quality.gap_detector import DuckDBQualityMetricWriter
+
+
+DEFAULT_DUPLICATE_THRESHOLDS = VPrismMetricThresholds(warn=1, fail=3)
+
+
+VPrismDuplicateMetricWriter = Callable[[QualityMetricRow], None]
+
+
+@dataclass(frozen=True)
+class VPrismDuplicateDetectionResult:
+    """Result of duplicate evaluation for a single symbol."""
+
+    duplicates: tuple[tuple[date, int], ...]
+    duplicate_total: int
+    status: VPrismQualityMetricStatus
+
+
+class VPrismDuplicateDetector:
+    """Detect duplicate trading days and persist metrics."""
+
+    def __init__(
+        self,
+        metric_writer: VPrismDuplicateMetricWriter,
+        duplicate_thresholds: VPrismMetricThresholds | None = None,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._metric_writer = metric_writer
+        self._thresholds = duplicate_thresholds or DEFAULT_DUPLICATE_THRESHOLDS
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def evaluate(
+        self,
+        *,
+        market: str,
+        symbol: str,
+        observed_timestamps: Sequence[date | datetime] | Iterable[date | datetime],
+        run_id: str,
+        metric_date: date | None = None,
+    ) -> VPrismDuplicateDetectionResult:
+        """Compute duplicate counts for the provided timestamps."""
+
+        normalized = self._normalize_dates(observed_timestamps)
+        counter = Counter(normalized)
+        duplicates = tuple(sorted((day, count) for day, count in counter.items() if count > 1))
+        duplicate_total = int(sum(count - 1 for _, count in duplicates))
+        status = vprism_classify_metric(float(duplicate_total), self._thresholds)
+
+        metric_row = QualityMetricRow(
+            date=metric_date or (max(normalized) if normalized else datetime.now(UTC).date()),
+            market=market,
+            supplier_symbol=symbol,
+            metric="duplicate_count",
+            value=float(duplicate_total),
+            status=status,
+            run_id=run_id,
+            created_at=self._clock(),
+        )
+        self._metric_writer(metric_row)
+
+        return VPrismDuplicateDetectionResult(
+            duplicates=duplicates,
+            duplicate_total=duplicate_total,
+            status=status,
+        )
+
+    @staticmethod
+    def _normalize_dates(
+        timestamps: Sequence[date | datetime] | Iterable[date | datetime],
+    ) -> list[date]:
+        normalized: list[date] = []
+        for value in timestamps:
+            current = value.date() if isinstance(value, datetime) else value
+            normalized.append(current)
+        return normalized
+
+
+__all__ = [
+    "DEFAULT_DUPLICATE_THRESHOLDS",
+    "VPrismDuplicateDetectionResult",
+    "VPrismDuplicateDetector",
+    "VPrismDuplicateMetricWriter",
+]


### PR DESCRIPTION
## Summary
- persist computed adjustment factors via a DuckDB writer with deterministic timestamps
- add pytest coverage ensuring adjustment rows are written and idempotent
- introduce a duplicate detector service that records quality metrics and tests covering duplicate/clean cases

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51a82f664832da2e2508fef9d180c