### PR TITLE
Implement plugin loader framework with conflict handling

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 21,
+      "todo": 18,
       "in_progress": 0,
-      "done": 32,
+      "done": 35,
       "prd_count": 10
     },
     "tasks": [
@@ -1570,7 +1570,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove plugin loader integration and tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "PluginLoader discovers vprism.plugins entry points, registering non-conflicting commands with Typer CLI"
       },
       {
         "id": "PRD-9-006",
@@ -1593,7 +1594,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove conflict detection enhancements and tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Conflict detection now warns and skips plugins that redefine command names, preserving load order logs"
       }
     ]
   },

--- a/tests/core/plugins/test_plugin_conflicts.py
+++ b/tests/core/plugins/test_plugin_conflicts.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import typer
+
+from vprism.core.plugins import PluginLoader
+
+
+@dataclass
+class DummyEntryPoint:
+    name: str
+    target: object
+
+    @property
+    def group(self) -> str:
+        return "vprism.plugins"
+
+    @property
+    def module(self) -> str:
+        return getattr(self.target, "__module__", "tests")
+
+    @property
+    def attr(self) -> str:
+        return getattr(self.target, "__name__", "register")
+
+    def load(self) -> object:
+        return self.target
+
+
+class DummyEntryPoints(list[DummyEntryPoint]):
+    def __init__(self, items: Iterable[DummyEntryPoint]):
+        if not isinstance(items, Iterable):
+            raise TypeError("items must be iterable")
+        super().__init__(items)
+
+    def select(self, *, group: str) -> DummyEntryPoints:
+        return DummyEntryPoints(ep for ep in self if ep.group == group)
+
+
+def base_plugin(cli_app: typer.Typer, services_registry):
+    @cli_app.command("alpha")
+    def alpha():  # pragma: no cover - Typer command body not executed
+        """Base command."""
+
+    services_registry.setdefault("commands", []).append("alpha")
+
+
+def conflicting_plugin(cli_app: typer.Typer, services_registry):
+    @cli_app.command("alpha")
+    def alpha():  # pragma: no cover - Typer command body not executed
+        """Conflicting command."""
+
+    services_registry.setdefault("commands", []).append("alpha-conflict")
+
+
+def test_conflicting_plugin_is_skipped(monkeypatch, caplog):
+    app = typer.Typer()
+    loader = PluginLoader()
+    registry = {}
+    entry_points = DummyEntryPoints(
+        [
+            DummyEntryPoint("base", base_plugin),
+            DummyEntryPoint("conflict", conflicting_plugin),
+        ]
+    )
+    monkeypatch.setattr("vprism.core.plugins.loader.metadata.entry_points", lambda: entry_points)
+    caplog.set_level("WARNING")
+
+    results = loader.load_plugins(app, registry)
+
+    assert [cmd.name for cmd in app.registered_commands] == ["alpha"]
+    assert results[0].commands == ("alpha",)
+    assert len(results) == 1
+    assert registry == {"commands": ["alpha", "alpha-conflict"]}
+    assert "skipping plugin" in caplog.text.lower()

--- a/tests/core/plugins/test_plugin_loader.py
+++ b/tests/core/plugins/test_plugin_loader.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import typer
+
+from vprism.core.plugins import PluginLoader
+
+
+@dataclass
+class DummyEntryPoint:
+    name: str
+    target: object
+
+    @property
+    def group(self) -> str:
+        return "vprism.plugins"
+
+    @property
+    def module(self) -> str:
+        return getattr(self.target, "__module__", "tests")
+
+    @property
+    def attr(self) -> str:
+        return getattr(self.target, "__name__", "register")
+
+    def load(self) -> object:
+        return self.target
+
+
+class DummyEntryPoints(list[DummyEntryPoint]):
+    def __init__(self, items: Iterable[DummyEntryPoint]):
+        if not isinstance(items, Iterable):
+            raise TypeError("items must be iterable")
+        super().__init__(items)
+
+    def select(self, *, group: str) -> DummyEntryPoints:
+        return DummyEntryPoints(ep for ep in self if ep.group == group)
+
+
+def sample_plugin(cli_app: typer.Typer, services_registry):
+    @cli_app.command("greet")
+    def greet():  # pragma: no cover - defined for Typer
+        """Dummy command."""
+
+    services_registry.setdefault("loaded", []).append("greet")
+
+
+def test_plugin_loader_registers_commands(monkeypatch):
+    app = typer.Typer()
+    loader = PluginLoader()
+    registry = {}
+    entry_points = DummyEntryPoints([DummyEntryPoint("sample", sample_plugin)])
+    monkeypatch.setattr("vprism.core.plugins.loader.metadata.entry_points", lambda: entry_points)
+
+    results = loader.load_plugins(app, registry)
+
+    assert registry == {"loaded": ["greet"]}
+    assert [cmd.name for cmd in app.registered_commands] == ["greet"]
+    assert len(results) == 1
+    assert results[0].commands == ("greet",)

--- a/vprism/cli/__init__.py
+++ b/vprism/cli/__init__.py
@@ -1,0 +1,5 @@
+"""Command line interface entry points for VPrism."""
+
+from .main import app, create_app, bootstrap_plugins
+
+__all__ = ["app", "create_app", "bootstrap_plugins"]

--- a/vprism/cli/main.py
+++ b/vprism/cli/main.py
@@ -1,0 +1,37 @@
+"""Main entry point for the VPrism command line interface."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+
+import typer
+
+from vprism.core.plugins import PluginLoader
+
+
+def create_app() -> typer.Typer:
+    """Create a Typer application instance for VPrism."""
+
+    return typer.Typer(add_completion=False, help="VPrism command line interface")
+
+
+def bootstrap_plugins(
+    cli_app: typer.Typer,
+    *,
+    services_registry: MutableMapping[str, object] | None = None,
+    loader: PluginLoader | None = None,
+) -> MutableMapping[str, object]:
+    """Load CLI plugins using the provided loader."""
+
+    if services_registry is not None and not isinstance(services_registry, MutableMapping):
+        msg = "services_registry must be a mutable mapping"
+        raise TypeError(msg)
+
+    registry = services_registry or {}
+    plugin_loader = loader or PluginLoader()
+    plugin_loader.load_plugins(cli_app, registry)
+    return registry
+
+
+app = create_app()
+bootstrap_plugins(app)

--- a/vprism/core/plugins/__init__.py
+++ b/vprism/core/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Plugin framework for the VPrism CLI."""
+
+from .loader import PluginLoader, PluginLoadResult
+
+__all__ = ["PluginLoader", "PluginLoadResult"]

--- a/vprism/core/plugins/loader.py
+++ b/vprism/core/plugins/loader.py
@@ -1,0 +1,117 @@
+"""Utilities for discovering and loading VPrism CLI plugins."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, MutableMapping
+from dataclasses import dataclass, field
+from importlib import metadata
+from typing import Any, Protocol
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PluginLoadResult:
+    """Represents the outcome of loading a single plugin."""
+
+    plugin_id: str
+    commands: tuple[str, ...] = field(default_factory=tuple)
+
+
+class TyperLike(Protocol):
+    registered_commands: list[Any]
+
+    def command(self, *args: Any, **kwargs: Any): ...
+
+
+class PluginLoader:
+    """Discover and register VPrism CLI plugins."""
+
+    def __init__(self, group: str = "vprism.plugins", logger: logging.Logger | None = None) -> None:
+        self.group = group
+        self.logger = logger or LOGGER
+
+    def load_plugins(
+        self,
+        cli_app: TyperLike,
+        services_registry: MutableMapping[str, object],
+    ) -> list[PluginLoadResult]:
+        """Load plugins and register their commands against the provided CLI app."""
+
+        if not isinstance(services_registry, MutableMapping):
+            msg = "services_registry must be a mutable mapping"
+            raise TypeError(msg)
+
+        results: list[PluginLoadResult] = []
+        for entry_point in self._iter_entry_points():
+            plugin_id = self._plugin_identifier(entry_point)
+            self.logger.info("Loading plugin %s", plugin_id)
+            try:
+                plugin = entry_point.load()
+            except Exception as exc:  # pragma: no cover - safety net
+                self.logger.exception("Failed to load plugin %s: %s", plugin_id, exc)
+                continue
+
+            register = self._resolve_register_callable(plugin, plugin_id)
+            if register is None:
+                continue
+
+            pre_commands = list(cli_app.registered_commands)
+            pre_names = {cmd.name for cmd in pre_commands}
+
+            try:
+                register(cli_app, services_registry)
+            except Exception as exc:
+                cli_app.registered_commands = pre_commands
+                self.logger.exception("Plugin %s raised during register: %s", plugin_id, exc)
+                continue
+
+            new_commands = [cmd for cmd in cli_app.registered_commands if cmd not in pre_commands]
+            conflicting = [cmd for cmd in new_commands if cmd.name in pre_names]
+            if conflicting:
+                cli_app.registered_commands = pre_commands
+                conflict_names = ", ".join(sorted({cmd.name for cmd in conflicting}))
+                self.logger.warning(
+                    "Plugin %s defines commands already registered (%s); skipping plugin.",
+                    plugin_id,
+                    conflict_names,
+                )
+                continue
+
+            for cmd in new_commands:
+                pre_names.add(cmd.name)
+
+            command_names = tuple(cmd.name for cmd in new_commands)
+            results.append(PluginLoadResult(plugin_id=plugin_id, commands=command_names))
+            joined = ", ".join(command_names) if command_names else "no commands"
+            self.logger.info("Plugin %s loaded with %s", plugin_id, joined)
+
+        return results
+
+    def _iter_entry_points(self) -> list[metadata.EntryPoint]:
+        eps = metadata.entry_points()
+        selected = (
+            eps.select(group=self.group)
+            if hasattr(eps, "select")
+            else eps.get(self.group, [])  # type: ignore[assignment]
+        )
+        return list(selected)
+
+    def _plugin_identifier(self, entry_point: metadata.EntryPoint) -> str:
+        module = getattr(entry_point, "module", "<unknown>")
+        attr = getattr(entry_point, "attr", None)
+        if attr:
+            return f"{module}:{attr}"
+        return module
+
+    def _resolve_register_callable(
+        self, plugin: object, plugin_id: str
+    ) -> Callable[[TyperLike, MutableMapping[str, object]], None] | None:
+        if isinstance(plugin, Callable):
+            return plugin
+        register = getattr(plugin, "register", None)
+        if callable(register):
+            return register
+        self.logger.warning("Plugin %s does not expose a register callable; skipping.", plugin_id)
+        return None


### PR DESCRIPTION
## Summary
- add a plugin loader that discovers `vprism.plugins` entry points, registers commands, and skips conflicting plugins with detailed logging
- expose CLI bootstrap helpers that initialise a Typer app and load plugins during startup
- add targeted tests for plugin registration and conflict handling while marking the PRD plan tasks as complete

## Testing
- uv run pytest tests/core/plugins
- uv run ruff check vprism/core/plugins/loader.py tests/core/plugins
- uv run ruff check vprism/cli/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d631bb1ac0832db5b7b3373370b6d1