### PR TITLE
Implement reconciliation schemas and service

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 18,
+      "todo": 16,
       "in_progress": 0,
-      "done": 35,
+      "done": 37,
       "prd_count": 10
     },
     "tasks": [
@@ -1067,7 +1067,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove reconciliation table definitions and tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Reconciliation run and diff tables defined in schema module with DuckDB tests covering structure."
       },
       {
         "id": "PRD-6-002",
@@ -1100,7 +1101,8 @@
         "risk_note": "HIGH",
         "rollback_hint": "Revert ReconciliationService implementation and tests.",
         "effort": "L",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "ReconciliationService performs sampling, computes bp/volume deltas, classifies statuses, and is validated by unit tests."
       },
       {
         "id": "PRD-6-003",

--- a/tests/core/data/test_reconciliation_schema.py
+++ b/tests/core/data/test_reconciliation_schema.py
@@ -1,0 +1,52 @@
+import duckdb
+
+from vprism.core.data import schema
+
+
+def test_reconciliation_tables_structure() -> None:
+    conn = duckdb.connect(database=":memory:")
+
+    schema.ensure_reconciliation_tables(conn)
+
+    runs_columns = conn.execute("PRAGMA table_info('reconciliation_runs')").fetchall()
+    assert [column[1] for column in runs_columns] == [
+        "run_id",
+        "market",
+        "start",
+        "end",
+        "source_a",
+        "source_b",
+        "sample_size",
+        "created_at",
+        "pass",
+        "warn",
+        "fail",
+        "p95_bp_diff",
+    ]
+    runs_pk = {column[1] for column in runs_columns if column[5] > 0}
+    assert runs_pk == {"run_id"}
+
+    diffs_columns = conn.execute("PRAGMA table_info('reconciliation_diffs')").fetchall()
+    assert [column[1] for column in diffs_columns] == [
+        "run_id",
+        "symbol",
+        "date",
+        "close_a",
+        "close_b",
+        "close_bp_diff",
+        "volume_a",
+        "volume_b",
+        "volume_ratio",
+        "status",
+    ]
+    diffs_pk = {column[1] for column in diffs_columns if column[5] > 0}
+    assert diffs_pk == {"run_id", "symbol", "date"}
+
+
+def test_reconciliation_table_ddl_idempotent() -> None:
+    conn = duckdb.connect(database=":memory:")
+
+    for ddl in schema.create_reconciliation_ddl():
+        conn.execute(ddl)
+    for ddl in schema.create_reconciliation_ddl():
+        conn.execute(ddl)

--- a/tests/core/services/test_reconciliation_service.py
+++ b/tests/core/services/test_reconciliation_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from decimal import Decimal
+from random import Random
+from typing import Sequence
+
+import pytest
+
+from vprism.core.exceptions.base import ReconciliationError
+from vprism.core.models.base import DataPoint
+from vprism.core.models.market import MarketType
+from vprism.core.services.reconciliation import (
+    PriceSeriesLoader,
+    ReconciliationService,
+    ReconciliationStatus,
+)
+
+
+def _make_point(
+    symbol: str,
+    day: date,
+    close: str,
+    volume: str,
+    provider: str,
+    market: MarketType = MarketType.CN,
+) -> DataPoint:
+    return DataPoint(
+        symbol=symbol,
+        market=market,
+        timestamp=datetime.combine(day, time.min),
+        close_price=Decimal(close),
+        volume=Decimal(volume),
+        provider=provider,
+    )
+
+
+def _loader_factory(data: dict[str, Sequence[DataPoint]]) -> PriceSeriesLoader:
+    def _loader(symbol: str, market: MarketType, start: date, end: date) -> Sequence[DataPoint]:
+        return data.get(symbol, [])
+
+    return _loader
+
+
+def test_reconcile_all_pass() -> None:
+    symbol = "AAA"
+    start = date(2024, 1, 1)
+    end = date(2024, 1, 3)
+    provider_a_data = {
+        symbol: [
+            _make_point(symbol, start, "100", "1000", "A"),
+            _make_point(symbol, date(2024, 1, 2), "101", "1100", "A"),
+            _make_point(symbol, end, "102", "900", "A"),
+        ]
+    }
+    provider_b_data = {
+        symbol: [
+            _make_point(symbol, start, "100", "1000", "B"),
+            _make_point(symbol, date(2024, 1, 2), "101", "1100", "B"),
+            _make_point(symbol, end, "102", "900", "B"),
+        ]
+    }
+
+    service = ReconciliationService(
+        _loader_factory(provider_a_data),
+        _loader_factory(provider_b_data),
+        source_a="akshare",
+        source_b="yfinance",
+        default_sample_size=5,
+        rng=Random(0),
+    )
+
+    result = service.reconcile([symbol], MarketType.CN, (start, end))
+
+    assert result.summary.pass_count == 3
+    assert result.summary.warn_count == 0
+    assert result.summary.fail_count == 0
+    assert result.summary.p95_close_bp_diff == Decimal("0")
+    assert result.sampled_symbols == (symbol,)
+    assert all(sample.status is ReconciliationStatus.PASS for sample in result.samples)
+
+
+def test_reconcile_warn_and_fail_classification() -> None:
+    symbol = "BBB"
+    start = date(2024, 1, 1)
+    provider_a_data = {
+        symbol: [
+            _make_point(symbol, start, "100", "1000", "A"),
+            _make_point(symbol, date(2024, 1, 2), "100.06", "1000", "A"),
+            _make_point(symbol, date(2024, 1, 3), "100.12", "1800", "A"),
+        ]
+    }
+    provider_b_data = {
+        symbol: [
+            _make_point(symbol, start, "100", "1000", "B"),
+            _make_point(symbol, date(2024, 1, 2), "100", "1000", "B"),
+            _make_point(symbol, date(2024, 1, 3), "100", "900", "B"),
+        ]
+    }
+
+    service = ReconciliationService(
+        _loader_factory(provider_a_data),
+        _loader_factory(provider_b_data),
+        source_a="akshare",
+        source_b="yfinance",
+        rng=Random(0),
+    )
+
+    result = service.reconcile([symbol], MarketType.CN, (start, date(2024, 1, 3)))
+
+    statuses = [sample.status for sample in result.samples]
+    assert statuses.count(ReconciliationStatus.PASS) == 1
+    assert statuses.count(ReconciliationStatus.WARN) == 1
+    assert statuses.count(ReconciliationStatus.FAIL) == 1
+    assert result.summary.pass_count == 1
+    assert result.summary.warn_count == 1
+    assert result.summary.fail_count == 1
+    assert result.summary.p95_close_bp_diff == Decimal("11.4")
+
+
+def test_reconcile_missing_provider_data_marks_fail() -> None:
+    symbol = "CCC"
+    start = date(2024, 1, 1)
+    end = date(2024, 1, 2)
+    provider_a_data = {
+        symbol: [
+            _make_point(symbol, start, "100", "1000", "A"),
+            _make_point(symbol, end, "101", "1000", "A"),
+        ]
+    }
+    provider_b_data: dict[str, Sequence[DataPoint]] = {symbol: []}
+
+    service = ReconciliationService(
+        _loader_factory(provider_a_data),
+        _loader_factory(provider_b_data),
+        source_a="akshare",
+        source_b="yfinance",
+    )
+
+    result = service.reconcile([symbol], MarketType.CN, (start, end))
+
+    assert all(sample.status is ReconciliationStatus.FAIL for sample in result.samples)
+    assert result.summary.fail_count == 2
+
+
+def test_reconcile_validates_inputs() -> None:
+    service = ReconciliationService(
+        _loader_factory({}),
+        _loader_factory({}),
+        source_a="akshare",
+        source_b="yfinance",
+    )
+
+    with pytest.raises(ReconciliationError):
+        service.reconcile([], MarketType.CN, (date(2024, 1, 1), date(2024, 1, 2)))
+
+    with pytest.raises(ReconciliationError):
+        service.reconcile(["AAA"], MarketType.CN, (date(2024, 1, 2), date(2024, 1, 1)))
+
+    with pytest.raises(ReconciliationError):
+        service.reconcile(["AAA"], MarketType.CN, (date(2024, 1, 1), date(2024, 1, 2)), sample_size=0)

--- a/vprism/core/exceptions/base.py
+++ b/vprism/core/exceptions/base.py
@@ -202,3 +202,19 @@ class UnresolvedSymbolError(VPrismError):
         self.raw_symbol = raw_symbol
         self.market = market
         self.asset_type = asset_type
+
+
+class ReconciliationError(VPrismError):
+    """对账流程异常."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        symbol: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super_details = details or {}
+        if symbol is not None:
+            super_details.setdefault("symbol", symbol)
+        super().__init__(message, "RECONCILIATION_ERROR", super_details)

--- a/vprism/core/services/__init__.py
+++ b/vprism/core/services/__init__.py
@@ -3,11 +3,13 @@
 from vprism.core.services.batch import BatchProcessor
 from vprism.core.services.data import DataService
 from vprism.core.services.drift import DriftService
+from vprism.core.services.reconciliation import ReconciliationService
 from vprism.core.services.routing import DataRouter
 
 __all__ = [
     "BatchProcessor",
     "DataService",
+    "ReconciliationService",
     "DataRouter",
     "DriftService",
 ]

--- a/vprism/core/services/reconciliation.py
+++ b/vprism/core/services/reconciliation.py
@@ -1,0 +1,291 @@
+"""Reconciliation service implementing PRD-6 sampling and classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, DivisionByZero, InvalidOperation
+from enum import Enum
+from random import Random
+from typing import Callable, Sequence
+
+from vprism.core.exceptions.base import ReconciliationError
+from vprism.core.models.base import DataPoint
+from vprism.core.models.market import MarketType
+
+PriceSeriesLoader = Callable[[str, MarketType, date, date], Sequence[DataPoint]]
+
+
+class ReconciliationStatus(str, Enum):
+    """Classification of reconciliation results."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class ReconciliationThresholds:
+    """Threshold configuration for reconciliation classification."""
+
+    close_warn: Decimal = Decimal("5")
+    close_fail: Decimal = Decimal("10")
+    volume_warn: Decimal = Decimal("1.2")
+    volume_fail: Decimal = Decimal("1.5")
+
+
+@dataclass(frozen=True)
+class ReconciliationSample:
+    """Single reconciliation comparison for a symbol/date."""
+
+    symbol: str
+    date: date
+    close_a: Decimal | None
+    close_b: Decimal | None
+    close_bp_diff: Decimal | None
+    volume_a: Decimal | None
+    volume_b: Decimal | None
+    volume_ratio: Decimal | None
+    status: ReconciliationStatus
+
+
+@dataclass(frozen=True)
+class ReconciliationSummary:
+    """Aggregated reconciliation run statistics."""
+
+    market: MarketType
+    start: date
+    end: date
+    source_a: str
+    source_b: str
+    sample_size: int
+    pass_count: int
+    warn_count: int
+    fail_count: int
+    p95_close_bp_diff: Decimal
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """Reconciliation result set including samples and summary."""
+
+    summary: ReconciliationSummary
+    sampled_symbols: tuple[str, ...]
+    samples: tuple[ReconciliationSample, ...]
+
+
+class ReconciliationService:
+    """Sample symbols from two providers and classify reconciliation outcomes."""
+
+    def __init__(
+        self,
+        provider_a_loader: PriceSeriesLoader,
+        provider_b_loader: PriceSeriesLoader,
+        *,
+        source_a: str,
+        source_b: str,
+        default_sample_size: int = 50,
+        thresholds: ReconciliationThresholds | None = None,
+        rng: Random | None = None,
+    ) -> None:
+        if default_sample_size <= 0:
+            raise ReconciliationError("default sample size must be positive")
+        self._provider_a_loader = provider_a_loader
+        self._provider_b_loader = provider_b_loader
+        self._source_a = source_a
+        self._source_b = source_b
+        self._default_sample_size = default_sample_size
+        self._thresholds = thresholds or ReconciliationThresholds()
+        self._rng = rng or Random()
+
+    def reconcile(
+        self,
+        symbols: Sequence[str],
+        market: MarketType,
+        date_range: tuple[date, date],
+        sample_size: int | None = None,
+    ) -> ReconcileResult:
+        if not symbols:
+            raise ReconciliationError("symbols list must not be empty")
+        start, end = date_range
+        if start > end:
+            raise ReconciliationError("start date must be on or before end date")
+        if sample_size is not None and sample_size <= 0:
+            raise ReconciliationError("sample size must be positive")
+
+        unique_symbols = list(dict.fromkeys(symbols))
+        requested_size = sample_size or self._default_sample_size
+        sample_count = min(len(unique_symbols), requested_size)
+        if sample_count == len(unique_symbols):
+            sampled = tuple(unique_symbols)
+        else:
+            sampled = tuple(self._rng.sample(unique_symbols, sample_count))
+
+        samples: list[ReconciliationSample] = []
+        pass_count = warn_count = fail_count = 0
+        abs_close_diffs: list[Decimal] = []
+
+        for symbol in sampled:
+            symbol_samples = self._reconcile_symbol(symbol, market, start, end)
+            for sample in symbol_samples:
+                samples.append(sample)
+                if sample.status is ReconciliationStatus.PASS:
+                    pass_count += 1
+                elif sample.status is ReconciliationStatus.WARN:
+                    warn_count += 1
+                else:
+                    fail_count += 1
+                if sample.close_bp_diff is not None:
+                    abs_close_diffs.append(abs(sample.close_bp_diff))
+
+        p95 = self._percentile(abs_close_diffs, Decimal("0.95")) if abs_close_diffs else Decimal("0")
+
+        summary = ReconciliationSummary(
+            market=market,
+            start=start,
+            end=end,
+            source_a=self._source_a,
+            source_b=self._source_b,
+            sample_size=len(sampled),
+            pass_count=pass_count,
+            warn_count=warn_count,
+            fail_count=fail_count,
+            p95_close_bp_diff=p95,
+        )
+        return ReconcileResult(summary=summary, sampled_symbols=sampled, samples=tuple(samples))
+
+    def _reconcile_symbol(
+        self,
+        symbol: str,
+        market: MarketType,
+        start: date,
+        end: date,
+    ) -> list[ReconciliationSample]:
+        series_a = self._provider_a_loader(symbol, market, start, end)
+        series_b = self._provider_b_loader(symbol, market, start, end)
+        indexed_a = self._index_by_date(series_a, start, end)
+        indexed_b = self._index_by_date(series_b, start, end)
+        dates = sorted(set(indexed_a) | set(indexed_b))
+
+        samples: list[ReconciliationSample] = []
+        for record_date in dates:
+            point_a = indexed_a.get(record_date)
+            point_b = indexed_b.get(record_date)
+            close_a = self._extract_decimal(point_a.close_price) if point_a else None
+            close_b = self._extract_decimal(point_b.close_price) if point_b else None
+            volume_a = self._extract_decimal(point_a.volume) if point_a else None
+            volume_b = self._extract_decimal(point_b.volume) if point_b else None
+            close_bp_diff = self._compute_close_bp_diff(close_a, close_b)
+            volume_ratio = self._compute_volume_ratio(volume_a, volume_b)
+            status = self._classify(close_bp_diff, volume_ratio, point_a is None, point_b is None)
+            samples.append(
+                ReconciliationSample(
+                    symbol=symbol,
+                    date=record_date,
+                    close_a=close_a,
+                    close_b=close_b,
+                    close_bp_diff=close_bp_diff,
+                    volume_a=volume_a,
+                    volume_b=volume_b,
+                    volume_ratio=volume_ratio,
+                    status=status,
+                )
+            )
+        return samples
+
+    @staticmethod
+    def _index_by_date(
+        points: Sequence[DataPoint], start: date, end: date
+    ) -> dict[date, DataPoint]:
+        indexed: dict[date, DataPoint] = {}
+        for point in points:
+            point_date = point.timestamp.date()
+            if start <= point_date <= end:
+                indexed[point_date] = point
+        return indexed
+
+    @staticmethod
+    def _extract_decimal(value: Decimal | float | int | None) -> Decimal | None:
+        if value is None:
+            return None
+        if isinstance(value, Decimal):
+            return value
+        return Decimal(str(value))
+
+    @staticmethod
+    def _compute_close_bp_diff(close_a: Decimal | None, close_b: Decimal | None) -> Decimal | None:
+        if close_a is None or close_b is None:
+            return None
+        if close_b == 0:
+            return None
+        try:
+            return (close_a - close_b) / close_b * Decimal("10000")
+        except (InvalidOperation, DivisionByZero):
+            return None
+
+    @staticmethod
+    def _compute_volume_ratio(volume_a: Decimal | None, volume_b: Decimal | None) -> Decimal | None:
+        if volume_a is None or volume_b is None:
+            return None
+        if volume_b == 0:
+            return None
+        try:
+            return volume_a / volume_b
+        except (InvalidOperation, DivisionByZero):
+            return None
+
+    def _classify(
+        self,
+        close_bp_diff: Decimal | None,
+        volume_ratio: Decimal | None,
+        missing_a: bool,
+        missing_b: bool,
+    ) -> ReconciliationStatus:
+        if missing_a or missing_b:
+            return ReconciliationStatus.FAIL
+
+        status = ReconciliationStatus.PASS
+
+        if close_bp_diff is None:
+            return ReconciliationStatus.FAIL
+        magnitude = abs(close_bp_diff)
+        if magnitude >= self._thresholds.close_fail:
+            status = ReconciliationStatus.FAIL
+        elif magnitude >= self._thresholds.close_warn:
+            status = ReconciliationStatus.WARN
+
+        if volume_ratio is None or volume_ratio <= 0:
+            return ReconciliationStatus.FAIL
+
+        deviation = max(volume_ratio, Decimal("1") / volume_ratio)
+        if deviation >= self._thresholds.volume_fail:
+            return ReconciliationStatus.FAIL
+        if deviation >= self._thresholds.volume_warn and status is ReconciliationStatus.PASS:
+            status = ReconciliationStatus.WARN
+        return status
+
+    @staticmethod
+    def _percentile(values: Sequence[Decimal], percentile: Decimal) -> Decimal:
+        if not values:
+            return Decimal("0")
+        sorted_values = sorted(values)
+        if len(sorted_values) == 1:
+            return sorted_values[0]
+        rank = (len(sorted_values) - 1) * percentile
+        lower_index = int(rank)
+        upper_index = min(lower_index + 1, len(sorted_values) - 1)
+        lower_value = sorted_values[lower_index]
+        upper_value = sorted_values[upper_index]
+        fraction = rank - Decimal(lower_index)
+        return lower_value + (upper_value - lower_value) * fraction
+
+
+__all__ = [
+    "PriceSeriesLoader",
+    "ReconcileResult",
+    "ReconciliationSample",
+    "ReconciliationService",
+    "ReconciliationStatus",
+    "ReconciliationSummary",
+    "ReconciliationThresholds",
+]


### PR DESCRIPTION
## Summary
- add reconciliation run and diff schema definitions with creation helpers
- implement the reconciliation service with sampling, classification, and new exception handling
- cover the new functionality with targeted pytest suites and update the PRD task plan

## Testing
- uv run pytest tests/core/data/test_reconciliation_schema.py
- uv run pytest tests/core/services/test_reconciliation_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ed0dadb0832da28883e6466e01f5