### PR TITLE
Add drift CLI reporting and persistence support

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 16,
+      "todo": 14,
       "in_progress": 0,
-      "done": 37,
+      "done": 39,
       "prd_count": 10
     },
     "tasks": [
@@ -1526,7 +1526,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove drift CLI module and tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Typer drift report command renders metrics/status for table and jsonl formats with validation covered by pytest tests/cli/test_drift_report_command.py"
       },
       {
         "id": "PRD-9-004",
@@ -1550,7 +1551,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove persistence hook and adjust tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "DriftService writes drift_metrics rows with unique run ids using DuckDBDriftMetricWriter validated by pytest tests/core/services/test_drift_persistence.py"
       },
       {
         "id": "PRD-9-005",

--- a/tests/cli/test_drift_report_command.py
+++ b/tests/cli/test_drift_report_command.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from typer.testing import CliRunner
+
+from vprism.cli import drift as drift_module
+from vprism.cli.main import create_app
+from vprism.core.data.schema import VPrismQualityMetricStatus
+from vprism.core.exceptions import DriftComputationError
+from vprism.core.models.market import MarketType
+from vprism.core.services.drift import DriftMetric, DriftResult
+
+
+class StubDriftService:
+    def __init__(self, result: DriftResult, *, error: Exception | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.calls: list[dict[str, object]] = []
+
+    def compute(
+        self,
+        *,
+        symbol: str,
+        market: MarketType,
+        window: int,
+        run_id: str | None = None,
+    ) -> DriftResult:
+        self.calls.append({"symbol": symbol, "market": market, "window": window, "run_id": run_id})
+        if self._error:
+            raise self._error
+        return self._result
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _build_result() -> DriftResult:
+    metrics = (
+        DriftMetric("close_mean", Decimal("10"), VPrismQualityMetricStatus.OK),
+        DriftMetric("close_std", Decimal("1"), VPrismQualityMetricStatus.OK),
+        DriftMetric("volume_mean", Decimal("100"), VPrismQualityMetricStatus.OK),
+        DriftMetric("volume_std", Decimal("10"), VPrismQualityMetricStatus.OK),
+        DriftMetric("zscore_latest_close", Decimal("2"), VPrismQualityMetricStatus.WARN),
+        DriftMetric("zscore_latest_volume", Decimal("0.5"), VPrismQualityMetricStatus.OK),
+    )
+    return DriftResult(
+        symbol="000001",
+        market=MarketType.CN,
+        window=5,
+        metrics=metrics,
+        latest_timestamp=datetime(2024, 1, 5, 15, 30, 0),
+        run_id="run-123",
+    )
+
+
+def test_report_table_output(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _build_result()
+    stub = StubDriftService(result)
+    monkeypatch.setattr(drift_module, "get_drift_service", lambda: stub)
+
+    app = create_app()
+    cli_result = runner.invoke(app, ["drift", "report", "000001", "--market", "cn", "--window", "5"])
+
+    assert cli_result.exit_code == 0, cli_result.output
+    assert "zscore_latest_close" in cli_result.output
+    assert "WARN" in cli_result.output
+    assert stub.calls == [
+        {"symbol": "000001", "market": MarketType.CN, "window": 5, "run_id": None}
+    ]
+
+
+def test_report_jsonl_output(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _build_result()
+    stub = StubDriftService(result)
+    monkeypatch.setattr(drift_module, "get_drift_service", lambda: stub)
+
+    app = create_app()
+    cli_result = runner.invoke(app, ["--format", "jsonl", "drift", "report", "000001"])
+
+    assert cli_result.exit_code == 0, cli_result.output
+    payloads = [json.loads(line) for line in cli_result.output.strip().splitlines()]
+    assert any(item["metric"] == "zscore_latest_close" for item in payloads)
+    assert all(item["run_id"] == "run-123" for item in payloads)
+
+
+def test_report_handles_invalid_window(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _build_result()
+    stub = StubDriftService(result)
+    monkeypatch.setattr(drift_module, "get_drift_service", lambda: stub)
+
+    app = create_app()
+    cli_result = runner.invoke(app, ["drift", "report", "000001", "--window", "1"])
+
+    assert cli_result.exit_code == 10
+    assert "INVALID_WINDOW" in cli_result.stderr
+
+
+def test_report_emits_data_quality_error(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    error = DriftComputationError(
+        "insufficient data",
+        symbol="000001",
+        market=MarketType.CN.value,
+        details={"window": 5},
+    )
+    result = _build_result()
+    stub = StubDriftService(result, error=error)
+    monkeypatch.setattr(drift_module, "get_drift_service", lambda: stub)
+
+    app = create_app()
+    cli_result = runner.invoke(app, ["drift", "report", "000001", "--window", "5"])
+
+    assert cli_result.exit_code == 30
+    assert "DRIFT_COMPUTATION_ERROR" in cli_result.stderr

--- a/tests/core/services/test_drift_persistence.py
+++ b/tests/core/services/test_drift_persistence.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from vprism.core.data.storage.duckdb_factory import VPrismDuckDBFactory
+from vprism.core.models.base import DataPoint
+from vprism.core.models.market import MarketType
+from vprism.core.services.drift import DuckDBDriftMetricWriter, DriftService
+
+
+@pytest.fixture()
+def duckdb_conn():
+    factory = VPrismDuckDBFactory()
+    with factory.connection() as conn:
+        yield conn
+
+
+def _build_history(start: datetime) -> list[DataPoint]:
+    history: list[DataPoint] = []
+    for offset, (close_value, volume_value) in enumerate(
+        [
+            ("10", "100"),
+            ("11", "110"),
+            ("12", "115"),
+            ("13", "120"),
+        ]
+    ):
+        history.append(
+            DataPoint(
+                symbol="000001",
+                market=MarketType.CN,
+                timestamp=start + timedelta(days=offset),
+                close_price=Decimal(close_value),
+                volume=Decimal(volume_value),
+            )
+        )
+    return history
+
+
+def test_persists_rows_for_each_metric(duckdb_conn) -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    history = _build_history(start)
+
+    def loader(*_: object) -> list[DataPoint]:
+        return list(history)
+
+    writer = DuckDBDriftMetricWriter(duckdb_conn)
+    fixed_now = datetime(2024, 2, 1, 12, 0, tzinfo=UTC)
+    service = DriftService(loader, metric_writer=writer, clock=lambda: fixed_now)
+
+    result = service.compute("000001", MarketType.CN, window=3)
+
+    rows = duckdb_conn.execute(
+        """
+        SELECT date, market, symbol, metric, value, status, "window", run_id, created_at
+        FROM drift_metrics
+        ORDER BY metric
+        """
+    ).fetchall()
+
+    assert len(rows) == 6
+    observed_run_ids = {row[7] for row in rows}
+    assert observed_run_ids == {result.run_id}
+    assert all(row[1] == MarketType.CN.value for row in rows)
+    assert all(row[2] == "000001" for row in rows)
+    assert rows[-1][0].isoformat() == "2024-01-04"
+    metric_names = [row[3] for row in rows]
+    assert "zscore_latest_close" in metric_names
+    assert "zscore_latest_volume" in metric_names
+    assert all(row[6] == 3 for row in rows)
+    expected_created_at = fixed_now.replace(tzinfo=None)
+    assert all(row[8] == expected_created_at for row in rows)
+
+
+def test_generates_unique_run_ids_per_execution(duckdb_conn) -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    history = _build_history(start)
+
+    def loader(*_: object) -> list[DataPoint]:
+        return list(history)
+
+    writer = DuckDBDriftMetricWriter(duckdb_conn)
+    clock_values = [datetime(2024, 3, 1, tzinfo=UTC), datetime(2024, 3, 2, tzinfo=UTC)]
+
+    def clock() -> datetime:
+        return clock_values.pop(0)
+
+    service = DriftService(loader, metric_writer=writer, clock=clock)
+
+    first = service.compute("000001", MarketType.CN, window=3)
+    second = service.compute("000001", MarketType.CN, window=3)
+
+    assert first.run_id != second.run_id
+
+    run_rows = duckdb_conn.execute(
+        "SELECT run_id FROM drift_metrics ORDER BY created_at"
+    ).fetchall()
+    assert len(run_rows) == 12
+    assert {value for (value,) in run_rows} == {first.run_id, second.run_id}

--- a/vprism/cli/drift.py
+++ b/vprism/cli/drift.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+
+import typer
+
+from vprism.core.exceptions import DriftComputationError, VPrismError
+from vprism.core.models.base import DataPoint
+from vprism.core.models.market import MarketType, TimeFrame
+from vprism.core.services.data import DataService
+from vprism.core.services.drift import DriftResult, DriftService
+
+from .constants import DATA_QUALITY_EXIT_CODE, SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .utils import emit_error, prepare_output
+
+
+drift_app = typer.Typer(help="Data drift diagnostics.")
+
+DRIFT_COLUMNS = [
+    "symbol",
+    "market",
+    "metric",
+    "value",
+    "status",
+    "window",
+    "run_id",
+    "timestamp",
+]
+
+
+def register(app: typer.Typer) -> None:
+    """Register drift commands on the root CLI application."""
+
+    app.add_typer(drift_app, name="drift", help="Analyze price drift metrics")
+
+
+def get_drift_service() -> DriftService:
+    """Factory hook returning a configured :class:`DriftService`."""
+
+    return DriftService(_load_price_history)
+
+
+def _load_price_history(symbol: str, market: MarketType, window: int) -> Sequence[DataPoint]:
+    service = DataService()
+    end_date = datetime.now(UTC).date()
+    start_date = end_date - timedelta(days=window * 4)
+    response = asyncio.run(
+        service.get(
+            symbols=symbol,
+            start=start_date.isoformat(),
+            end=end_date.isoformat(),
+            market=market,
+            timeframe=TimeFrame.DAY_1,
+        )
+    )
+    return response.data
+
+
+@drift_app.command("report")
+def report_command(
+    ctx: typer.Context,
+    symbol: str = typer.Argument(..., help="Symbol to analyse for drift."),
+    market: str = typer.Option("cn", "--market", help="Market for the symbol."),
+    window: int = typer.Option(30, "--window", help="Lookback window size."),
+) -> None:
+    """Compute drift metrics for a symbol and render the result."""
+
+    formatter, stream, stack, _ = prepare_output(ctx)
+
+    try:
+        market_type = MarketType(market.lower())
+    except ValueError as exc:
+        allowed = ", ".join(sorted(value.value for value in MarketType))
+        raise typer.BadParameter(
+            f"Unsupported market '{market}'. Allowed values: {allowed}",
+            param_hint="--market",
+        ) from exc
+
+    if window < 2:
+        emit_error(
+            "Window must be at least 2 trading days.",
+            "INVALID_WINDOW",
+            details={"window": window},
+        )
+        raise typer.Exit(code=VALIDATION_EXIT_CODE)
+
+    service = get_drift_service()
+    try:
+        result = service.compute(symbol=symbol, market=market_type, window=window)
+    except DriftComputationError as error:
+        emit_error(error.message, error.error_code, details=error.details)
+        raise typer.Exit(code=DATA_QUALITY_EXIT_CODE) from error
+    except VPrismError as error:
+        emit_error(error.message, error.error_code, details=error.details)
+        raise typer.Exit(code=SYSTEM_EXIT_CODE) from error
+    except Exception as error:  # pragma: no cover - defensive guard
+        emit_error(str(error), "UNEXPECTED_ERROR")
+        raise typer.Exit(code=SYSTEM_EXIT_CODE) from error
+
+    rows = _result_to_rows(result)
+    try:
+        formatter.render(rows, stream=stream, columns=DRIFT_COLUMNS)
+    finally:
+        stack.close()
+
+
+def _result_to_rows(result: DriftResult) -> list[Mapping[str, object]]:
+    rows: list[Mapping[str, object]] = []
+    for metric in result.metrics:
+        rows.append(
+            {
+                "symbol": result.symbol,
+                "market": result.market.value,
+                "metric": metric.name,
+                "value": metric.value,
+                "status": metric.status.value,
+                "window": result.window,
+                "run_id": result.run_id,
+                "timestamp": result.latest_timestamp.isoformat(),
+            }
+        )
+    return rows
+
+
+__all__ = ["DRIFT_COLUMNS", "drift_app", "get_drift_service", "register", "report_command"]

--- a/vprism/cli/main.py
+++ b/vprism/cli/main.py
@@ -11,6 +11,7 @@ import typer
 from vprism.core.plugins import PluginLoader
 
 from .data import register as register_data_commands
+from .drift import register as register_drift_commands
 from .formatters import create_formatter
 from .symbol import register as register_symbol_commands
 
@@ -67,6 +68,7 @@ def create_app() -> typer.Typer:
         _configure_logging(log_level)
 
     register_data_commands(app)
+    register_drift_commands(app)
     register_symbol_commands(app)
     return app
 

--- a/vprism/core/services/__init__.py
+++ b/vprism/core/services/__init__.py
@@ -2,7 +2,7 @@
 
 from vprism.core.services.batch import BatchProcessor
 from vprism.core.services.data import DataService
-from vprism.core.services.drift import DriftService
+from vprism.core.services.drift import DuckDBDriftMetricWriter, DriftService
 from vprism.core.services.reconciliation import ReconciliationService
 from vprism.core.services.routing import DataRouter
 
@@ -12,4 +12,5 @@ __all__ = [
     "ReconciliationService",
     "DataRouter",
     "DriftService",
+    "DuckDBDriftMetricWriter",
 ]


### PR DESCRIPTION
## Summary
- add a DuckDB-backed drift metric writer and run identifier support to DriftService
- implement a Typer-based `drift report` command with validation and shared formatting helpers
- cover the new persistence and CLI flows with dedicated pytest suites and mark the related PRD tasks as complete

## Testing
- uv run pytest tests/core/services/test_drift_service.py tests/core/services/test_drift_persistence.py tests/cli/test_drift_report_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f6cbaeac832d97cff4367abff7e8