### PR TITLE
Add Prometheus metrics collector and FastAPI endpoint

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 11,
+      "todo": 10,
       "in_progress": 0,
-      "done": 42,
+      "done": 43,
       "prd_count": 10
     },
     "tasks": [
@@ -1201,7 +1201,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove metrics collector and web endpoint modules.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Prometheus MetricsCollector with query latency, failure counters, and FastAPI /metrics endpoint implemented with coverage in pytest tests/core/monitoring/test_metrics_collector.py and tests/web/test_metrics_endpoint.py"
       },
       {
         "id": "PRD-7-003",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "yfinance>=0.2.65",
     "aiohttp>=3.12.14",
     "fastmcp>=2.10.6",
+    "prometheus-client>=0.20.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/core/monitoring/test_metrics_collector.py
+++ b/tests/core/monitoring/test_metrics_collector.py
@@ -1,0 +1,58 @@
+"""Tests for the Prometheus metrics collector."""
+
+from prometheus_client import CollectorRegistry
+
+from vprism.core.monitoring.metrics import MetricsCollector
+
+
+def test_observe_query_updates_metrics() -> None:
+    registry = CollectorRegistry()
+    collector = MetricsCollector(registry=registry)
+
+    collector.observe_query("alpha", 0.25, success=True)
+    collector.observe_query("alpha", 0.40, success=False)
+
+    count = registry.get_sample_value("vprism_query_latency_seconds_count")
+    total_latency = registry.get_sample_value("vprism_query_latency_seconds_sum")
+    total_requests = registry.get_sample_value(
+        "vprism_query_requests_total",
+        {"provider": "alpha"},
+    )
+    total_failures = registry.get_sample_value(
+        "vprism_query_failures_total",
+        {"provider": "alpha"},
+    )
+    error_rate = registry.get_sample_value(
+        "vprism_provider_error_rate",
+        {"provider": "alpha"},
+    )
+
+    assert count == 2.0
+    assert total_latency == 0.65
+    assert total_requests == 2.0
+    assert total_failures == 1.0
+    assert error_rate == 0.5
+
+
+def test_increment_failure_without_latency_updates_counters() -> None:
+    registry = CollectorRegistry()
+    collector = MetricsCollector(registry=registry)
+
+    collector.increment_failure("beta")
+
+    total_requests = registry.get_sample_value(
+        "vprism_query_requests_total",
+        {"provider": "beta"},
+    )
+    total_failures = registry.get_sample_value(
+        "vprism_query_failures_total",
+        {"provider": "beta"},
+    )
+    error_rate = registry.get_sample_value(
+        "vprism_provider_error_rate",
+        {"provider": "beta"},
+    )
+
+    assert total_requests == 1.0
+    assert total_failures == 1.0
+    assert error_rate == 1.0

--- a/tests/web/test_metrics_endpoint.py
+++ b/tests/web/test_metrics_endpoint.py
@@ -1,0 +1,26 @@
+"""Integration tests for the metrics endpoint."""
+
+from fastapi.testclient import TestClient
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry
+
+from vprism.core.monitoring.metrics import MetricsCollector, configure_metrics_collector
+from vprism.web.app import create_app
+
+
+def test_metrics_endpoint_exposes_prometheus_payload() -> None:
+    registry = CollectorRegistry()
+    collector = MetricsCollector(registry=registry)
+    configure_metrics_collector(collector)
+
+    app = create_app()
+    collector.observe_query("alpha", 0.12, success=True)
+
+    client = TestClient(app)
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert "vprism_query_latency_seconds" in response.text
+    assert "vprism_query_requests_total" in response.text
+    assert response.headers["content-type"] == CONTENT_TYPE_LATEST
+
+    configure_metrics_collector(None)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -995,6 +995,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1665,6 +1674,7 @@ dependencies = [
     { name = "nest-asyncio" },
     { name = "pandas" },
     { name = "polars" },
+    { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytest" },
@@ -1704,6 +1714,7 @@ requires-dist = [
     { name = "nest-asyncio", specifier = ">=1.5.0" },
     { name = "pandas", specifier = ">=2.1.0" },
     { name = "polars", specifier = ">=0.19.0" },
+    { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=8.4.1" },

--- a/vprism/core/monitoring/__init__.py
+++ b/vprism/core/monitoring/__init__.py
@@ -7,6 +7,11 @@ from vprism.core.monitoring.health import (
     get_health_checker,
 )
 from vprism.core.monitoring.logging import PerformanceLogger, StructuredLogger, bind
+from vprism.core.monitoring.metrics import (
+    MetricsCollector,
+    configure_metrics_collector,
+    get_metrics_collector,
+)
 
 __all__ = [
     "HealthChecker",
@@ -16,4 +21,7 @@ __all__ = [
     "StructuredLogger",
     "PerformanceLogger",
     "bind",
+    "MetricsCollector",
+    "get_metrics_collector",
+    "configure_metrics_collector",
 ]

--- a/vprism/core/monitoring/metrics.py
+++ b/vprism/core/monitoring/metrics.py
@@ -1,0 +1,94 @@
+"""Prometheus metrics helpers for VPrism services."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import DefaultDict
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+
+
+@dataclass
+class _ProviderStats:
+    """Internal container tracking provider level success and failure counts."""
+
+    total: int = 0
+    failures: int = 0
+
+
+class MetricsCollector:
+    """Collects and exposes core Prometheus metrics for service operations."""
+
+    def __init__(self, *, registry: CollectorRegistry | None = None) -> None:
+        self.registry = registry or CollectorRegistry()
+        self.query_latency_seconds = Histogram(
+            "vprism_query_latency_seconds",
+            "Latency distribution for upstream data provider queries.",
+            buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")),
+            registry=self.registry,
+        )
+        self.query_requests_total = Counter(
+            "vprism_query_requests_total",
+            "Total count of upstream data provider queries.",
+            ("provider",),
+            registry=self.registry,
+        )
+        self.query_failures_total = Counter(
+            "vprism_query_failures_total",
+            "Total count of failed upstream data provider queries.",
+            ("provider",),
+            registry=self.registry,
+        )
+        self.provider_error_rate = Gauge(
+            "vprism_provider_error_rate",
+            "Rolling error rate for upstream data providers (0-1 range).",
+            ("provider",),
+            registry=self.registry,
+        )
+        self._provider_stats: DefaultDict[str, _ProviderStats] = defaultdict(_ProviderStats)
+
+    def observe_query(self, provider: str, latency_seconds: float, *, success: bool = True) -> None:
+        """Record a provider query execution."""
+
+        self.query_latency_seconds.observe(latency_seconds)
+        self._record_outcome(provider=provider, success=success)
+
+    def increment_failure(self, provider: str) -> None:
+        """Increment failure counters when a query fails before latency is captured."""
+
+        self._record_outcome(provider=provider, success=False)
+
+    def render(self) -> bytes:
+        """Render metrics in Prometheus exposition format."""
+
+        return generate_latest(self.registry)
+
+    def _record_outcome(self, *, provider: str, success: bool) -> None:
+        stats = self._provider_stats[provider]
+        stats.total += 1
+        self.query_requests_total.labels(provider=provider).inc()
+        if not success:
+            stats.failures += 1
+            self.query_failures_total.labels(provider=provider).inc()
+        error_rate = stats.failures / stats.total if stats.total else 0.0
+        self.provider_error_rate.labels(provider=provider).set(error_rate)
+
+
+_DEFAULT_COLLECTOR: MetricsCollector | None = None
+
+
+def get_metrics_collector() -> MetricsCollector:
+    """Return the global metrics collector instance."""
+
+    global _DEFAULT_COLLECTOR
+    if _DEFAULT_COLLECTOR is None:
+        _DEFAULT_COLLECTOR = MetricsCollector()
+    return _DEFAULT_COLLECTOR
+
+
+def configure_metrics_collector(collector: MetricsCollector | None) -> None:
+    """Override the global metrics collector for application wiring or tests."""
+
+    global _DEFAULT_COLLECTOR
+    _DEFAULT_COLLECTOR = collector

--- a/vprism/web/app.py
+++ b/vprism/web/app.py
@@ -20,7 +20,7 @@ from vprism.core.client import VPrismClient
 from vprism.core.config import ConfigManager
 from vprism.core.exceptions import VPrismError
 from vprism.web.models import ErrorResponse
-from vprism.web.routes import data_router, health_router
+from vprism.web.routes import data_router, health_router, metrics_router
 
 
 # Custom JSON encoder for datetime and Decimal
@@ -153,6 +153,7 @@ def _setup_routes(app: FastAPI) -> None:
     """注册路由"""
     app.include_router(data_router, prefix="/api/v1/data", tags=["data"])
     app.include_router(health_router, prefix="/api/v1", tags=["health"])
+    app.include_router(metrics_router, tags=["metrics"])
 
 
 def _setup_exception_handlers(app: FastAPI) -> None:

--- a/vprism/web/metrics.py
+++ b/vprism/web/metrics.py
@@ -1,0 +1,17 @@
+"""FastAPI utilities for Prometheus metrics exposure."""
+
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from vprism.core.monitoring.metrics import get_metrics_collector
+
+
+router = APIRouter()
+
+
+@router.get("/metrics", include_in_schema=False, summary="Prometheus metrics endpoint")
+def metrics_endpoint() -> Response:
+    """Expose collected metrics in Prometheus text format."""
+
+    collector = get_metrics_collector()
+    return Response(content=collector.render(), media_type=CONTENT_TYPE_LATEST)

--- a/vprism/web/routes/__init__.py
+++ b/vprism/web/routes/__init__.py
@@ -2,7 +2,8 @@
 Web API 路由模块
 """
 
+from vprism.web.metrics import router as metrics_router
 from vprism.web.routes.data_routes import router as data_router
 from vprism.web.routes.health_routes import router as health_router
 
-__all__ = ["data_router", "health_router"]
+__all__ = ["data_router", "health_router", "metrics_router"]


### PR DESCRIPTION
## Summary
- add a Prometheus-backed MetricsCollector with latency, request, failure, and error-rate telemetry plus a FastAPI /metrics endpoint
- cover the collector primitives and endpoint integration with focused pytest suites
- record completion of PRD-7-002 and add the prometheus-client dependency

## Testing
- uv run pytest tests/core/monitoring/test_metrics_collector.py tests/web/test_metrics_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68dba3a2d4b0832d93bab21e5eb90966