### PR TITLE
Add coverage for symbol service global metrics collector wiring

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -15,9 +15,9 @@
   "plan": {
     "summary": {
       "total": 53,
-      "todo": 10,
+      "todo": 6,
       "in_progress": 0,
-      "done": 43,
+      "done": 47,
       "prd_count": 10
     },
     "tasks": [
@@ -1252,7 +1252,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove metrics hookup and adjust tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "SymbolService now emits vprism_symbol_normalization_total counters for total, cache hits, misses, resolved, and unresolved events via MetricsCollector integration with Prometheus-backed tests in tests/core/services/test_symbol_metrics.py"
       },
       {
         "id": "PRD-7-005",

--- a/tests/core/monitoring/test_metrics_collector.py
+++ b/tests/core/monitoring/test_metrics_collector.py
@@ -56,3 +56,29 @@ def test_increment_failure_without_latency_updates_counters() -> None:
     assert total_requests == 1.0
     assert total_failures == 1.0
     assert error_rate == 1.0
+
+
+def test_record_symbol_normalization_tracks_allowed_statuses() -> None:
+    registry = CollectorRegistry()
+    collector = MetricsCollector(registry=registry)
+
+    collector.record_symbol_normalization("cache_hit")
+    collector.record_symbol_normalization("resolved")
+    collector.record_symbol_normalization("unexpected")
+
+    cache_hit = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "cache_hit"},
+    )
+    resolved = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "resolved"},
+    )
+    other = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "__other__"},
+    )
+
+    assert cache_hit == 1.0
+    assert resolved == 1.0
+    assert other == 1.0

--- a/tests/core/services/test_symbol_metrics.py
+++ b/tests/core/services/test_symbol_metrics.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import re
 
 import pytest
+from prometheus_client import CollectorRegistry
 
 from vprism.core.exceptions.base import UnresolvedSymbolError
 from vprism.core.models.market import AssetType, MarketType
 from vprism.core.models.symbols import SymbolRule
+from vprism.core.monitoring.metrics import (
+    MetricsCollector,
+    configure_metrics_collector,
+)
 from vprism.core.services.symbols import SymbolService
 
 
@@ -21,6 +26,14 @@ def metrics_service() -> SymbolService:
         asset_scope=frozenset({AssetType.STOCK}),
     )
     return SymbolService(rules=[numeric_rule])
+
+
+@pytest.fixture()
+def collector_service(metrics_service: SymbolService) -> tuple[SymbolService, CollectorRegistry]:
+    registry = CollectorRegistry()
+    collector = MetricsCollector(registry=registry)
+    service = SymbolService(rules=metrics_service.rules, metrics_collector=collector)
+    return service, registry
 
 
 def test_metrics_capture_cache_behavior(metrics_service: SymbolService) -> None:
@@ -50,3 +63,74 @@ def test_metrics_track_unresolved(metrics_service: SymbolService) -> None:
     metrics = service.get_metrics()
     assert metrics["unresolved_count"] == 1
     assert metrics["total_requests"] == 1
+
+
+def test_metrics_collector_tracks_symbol_statuses(
+    collector_service: tuple[SymbolService, CollectorRegistry],
+) -> None:
+    service, registry = collector_service
+
+    service.normalize("600010", MarketType.CN, AssetType.STOCK)
+    service.normalize("600010", MarketType.CN, AssetType.STOCK)
+    with pytest.raises(UnresolvedSymbolError):
+        service.normalize("BAD000", MarketType.CN, AssetType.STOCK)
+
+    total = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "total"},
+    )
+    cache_hit = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "cache_hit"},
+    )
+    cache_miss = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "cache_miss"},
+    )
+    unresolved = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "unresolved"},
+    )
+    resolved = registry.get_sample_value(
+        "vprism_symbol_normalization_total",
+        {"status": "resolved"},
+    )
+
+    assert total == 3.0
+    assert cache_hit == 1.0
+    assert cache_miss == 2.0
+    assert unresolved == 1.0
+    assert resolved == 2.0
+
+
+def test_service_uses_global_metrics_collector() -> None:
+    registry = CollectorRegistry()
+    collector = MetricsCollector(registry=registry)
+    configure_metrics_collector(collector)
+
+    try:
+        numeric_rule = SymbolRule(
+            id="cn_numeric",
+            priority=10,
+            pattern=re.compile(r"^(?P<code>\d{6})$"),
+            transform=lambda raw, match: match.group("code"),
+            market_scope=frozenset({MarketType.CN}),
+            asset_scope=frozenset({AssetType.STOCK}),
+        )
+        service = SymbolService(rules=[numeric_rule])
+
+        service.normalize("600010", MarketType.CN, AssetType.STOCK)
+
+        total = registry.get_sample_value(
+            "vprism_symbol_normalization_total",
+            {"status": "total"},
+        )
+        resolved = registry.get_sample_value(
+            "vprism_symbol_normalization_total",
+            {"status": "resolved"},
+        )
+
+        assert total == 1.0
+        assert resolved == 1.0
+    finally:
+        configure_metrics_collector(None)

--- a/vprism/core/monitoring/metrics.py
+++ b/vprism/core/monitoring/metrics.py
@@ -46,7 +46,19 @@ class MetricsCollector:
             ("provider",),
             registry=self.registry,
         )
+        self.symbol_normalization_total = Counter(
+            "vprism_symbol_normalization_total",
+            "Symbol normalization outcomes grouped by cache and resolution status.",
+            ("status",),
+            registry=self.registry,
+        )
         self._provider_stats: DefaultDict[str, _ProviderStats] = defaultdict(_ProviderStats)
+
+    def record_symbol_normalization(self, status: str) -> None:
+        """Track symbol normalization activity with constrained status labels."""
+
+        label = status if status in _ALLOWED_SYMBOL_STATUSES else "__other__"
+        self.symbol_normalization_total.labels(status=label).inc()
 
     def observe_query(self, provider: str, latency_seconds: float, *, success: bool = True) -> None:
         """Record a provider query execution."""
@@ -92,3 +104,12 @@ def configure_metrics_collector(collector: MetricsCollector | None) -> None:
 
     global _DEFAULT_COLLECTOR
     _DEFAULT_COLLECTOR = collector
+
+
+_ALLOWED_SYMBOL_STATUSES = {
+    "total",
+    "cache_hit",
+    "cache_miss",
+    "resolved",
+    "unresolved",
+}


### PR DESCRIPTION
## Summary
- extend the symbol metrics test suite to exercise configure_metrics_collector usage
- verify SymbolService binds to the global metrics collector and emits total/resolved counters

## Testing
- uv run pytest tests/core/services/test_symbol_metrics.py tests/core/monitoring/test_metrics_collector.py

------
https://chatgpt.com/codex/tasks/task_e_68de81486de0832d9d263778d43cb2c1