### PR TITLE
Add shadow controller workflow and CLI commands

### DIFF
--- a/docs/prd_plan.json
+++ b/docs/prd_plan.json
@@ -1276,7 +1276,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove slow query logging hooks and tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "SlowQueryLogger now emits warnings via vprism/core/monitoring/performance.py with coverage in tests/core/monitoring/test_slow_query_logging.py"
       },
       {
         "id": "PRD-8-001",
@@ -1299,7 +1300,8 @@
         "risk_note": "HIGH",
         "rollback_hint": "Remove ShadowController implementation and tests.",
         "effort": "L",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "ShadowController executes dual paths with sampling controls in vprism/core/services/shadow.py and is validated by tests/core/services/test_shadow_controller.py"
       },
       {
         "id": "PRD-8-002",
@@ -1322,7 +1324,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove diff engine logic and tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "DiffEngine compares results and classifies metrics in vprism/core/services/shadow_diff.py backed by tests/core/services/test_shadow_diff_engine.py"
       },
       {
         "id": "PRD-8-003",
@@ -1372,7 +1375,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove persistence and promote flag logic.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Shadow run persistence via vprism_shadow_runs_table and DuckDB writer implemented with tests/core/services/test_shadow_persistence.py"
       },
       {
         "id": "PRD-8-004",
@@ -1400,7 +1404,8 @@
         "risk_note": "MEDIUM",
         "rollback_hint": "Remove shadow CLI modules and tests.",
         "effort": "M",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "Typer shadow commands added in vprism/cli/shadow.py with coverage from tests/cli/test_shadow_commands.py"
       },
       {
         "id": "PRD-8-005",
@@ -1424,7 +1429,8 @@
         "risk_note": "LOW",
         "rollback_hint": "Remove pass-counter guard logic and tests.",
         "effort": "S",
-        "status": "TODO"
+        "status": "DONE",
+        "completion_note": "ShadowPromoteGuard enforces consecutive PASS runs in vprism/core/services/shadow.py with verification in tests/core/services/test_shadow_promote_guard.py"
       },
       {
         "id": "PRD-9-001",

--- a/tests/cli/test_shadow_commands.py
+++ b/tests/cli/test_shadow_commands.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta, date
+
+import pytest
+from typer.testing import CliRunner
+
+from vprism.cli import shadow as shadow_module
+from vprism.cli.main import create_app
+from vprism.cli.constants import VALIDATION_EXIT_CODE
+from vprism.core.services.shadow import (
+    ShadowController,
+    ShadowPromoteGuard,
+    ShadowRunConfig,
+    ShadowRunSummary,
+    ShadowSamplingPolicy,
+)
+from vprism.core.services.shadow_diff import DiffEngine, ShadowRecord
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._current = datetime(2024, 1, 1, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        value = self._current
+        self._current += timedelta(milliseconds=25)
+        return value
+
+
+def _make_record(offset: int, close: float) -> ShadowRecord:
+    timestamp = datetime(2024, 1, 1 + offset, tzinfo=UTC)
+    return ShadowRecord(symbol="asset-1", market="cn", timestamp=timestamp, close=close)
+
+
+def _primary(_: ShadowRunConfig) -> tuple[ShadowRecord, ...]:
+    return (_make_record(0, 10.0), _make_record(1, 10.2))
+
+
+def _candidate(_: ShadowRunConfig) -> tuple[ShadowRecord, ...]:
+    return (_make_record(0, 10.05), _make_record(1, 10.25))
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def configure_controller(monkeypatch: pytest.MonkeyPatch) -> Callable[..., ShadowController]:
+    def _configure(*, guard_passes: int = 1) -> ShadowController:
+        summaries: list[ShadowRunSummary] = []
+        controller = ShadowController(
+            _primary,
+            _candidate,
+            diff_engine=DiffEngine(),
+            sampling_policy=ShadowSamplingPolicy(default_sample_percent=100.0),
+            run_writer=summaries.append,
+            promote_guard=ShadowPromoteGuard(required_passes=guard_passes),
+            clock=FakeClock(),
+        )
+        monkeypatch.setattr(shadow_module, "get_shadow_controller", lambda: controller)
+        return controller
+
+    return _configure
+
+
+def test_shadow_run_command_outputs_summary(runner: CliRunner, configure_controller: Callable[..., ShadowController]) -> None:
+    configure_controller()
+    app = create_app()
+
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "jsonl",
+            "shadow",
+            "run",
+            "asset-1",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-02",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payloads = [json.loads(line) for line in result.output.strip().splitlines()]
+    assert payloads
+    assert payloads[0]["status"] == "PASS"
+    assert "row_diff_pct" in payloads[0]
+
+
+def test_shadow_status_command_shows_state(
+    runner: CliRunner, configure_controller: Callable[..., ShadowController]
+) -> None:
+    controller = configure_controller()
+    controller.run(
+        ShadowRunConfig(
+            asset="asset-1",
+            markets=("cn",),
+            start=date(2024, 1, 1),
+            end=date(2024, 1, 2),
+            sample_percent=100.0,
+        ),
+        wait_for_shadow=True,
+    )
+    app = create_app()
+
+    result = runner.invoke(app, ["--format", "jsonl", "shadow", "status"])
+
+    assert result.exit_code == 0
+    json_payloads: list[dict[str, object]] = []
+    state_lines: list[str] = []
+    for line in result.output.strip().splitlines():
+        if line.startswith("active_mode=") or line.startswith("ready_for_promote=") or line.startswith("consecutive_passes="):
+            state_lines.append(line)
+        elif line:
+            json_payloads.append(json.loads(line))
+    assert json_payloads
+    assert json_payloads[0]["status"] == "PASS"
+    assert any(item.startswith("active_mode=") for item in state_lines)
+
+
+def test_shadow_promote_command_respects_guard(
+    runner: CliRunner, configure_controller: Callable[..., ShadowController]
+) -> None:
+    configure_controller(guard_passes=2)
+    app = create_app()
+
+    result = runner.invoke(app, ["shadow", "promote"])
+
+    assert result.exit_code == VALIDATION_EXIT_CODE
+    assert "Shadow controller is not ready" in result.stderr
+
+    force_result = runner.invoke(app, ["shadow", "promote", "--force"])
+    assert force_result.exit_code == 0
+    assert "Shadow path promoted." in force_result.output

--- a/tests/core/monitoring/test_slow_query_logging.py
+++ b/tests/core/monitoring/test_slow_query_logging.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from loguru import logger
+
+from vprism.core.monitoring.performance import (
+    SlowQueryLogger,
+    SlowQueryThresholds,
+)
+
+
+class FakeTimer:
+    def __init__(self, values: Iterator[float]) -> None:
+        self._iterator = iter(values)
+
+    def __call__(self) -> float:
+        return next(self._iterator)
+
+
+def test_track_emits_warning_when_threshold_exceeded() -> None:
+    timer = FakeTimer([0.0, 0.25])
+    slow_logger = SlowQueryLogger(
+        thresholds=SlowQueryThresholds(p95_ms=100.0),
+        time_source=timer,
+    )
+    records: list[dict[str, object]] = []
+
+    def _capture(message: Any) -> None:
+        snapshot = dict(message.record)
+        snapshot["extra"] = dict(message.record.get("extra", {}))
+        records.append(snapshot)
+
+    handler_id = logger.add(_capture, level="WARNING")
+
+    try:
+        with slow_logger.track("quote_fetch", attributes={"supplier": "alpha"}):
+            pass
+    finally:
+        logger.remove(handler_id)
+
+    assert records, "expected a slow query warning to be emitted"
+    log_record = records[0]
+    assert log_record["message"] == "slow query detected for quote_fetch"
+    assert isinstance(log_record.get("extra"), dict)
+
+
+def test_observe_returns_non_slow_result() -> None:
+    slow_logger = SlowQueryLogger(thresholds=SlowQueryThresholds(p95_ms=150.0))
+    observation = slow_logger.observe(
+        "quote_fetch",
+        75.0,
+        attributes={"supplier": "beta"},
+    )
+
+    assert observation.is_slow is False
+    assert observation.duration_ms == pytest.approx(75.0)
+    assert observation.threshold_ms == 150.0
+    assert observation.attributes == {"supplier": "beta"}

--- a/tests/core/services/test_shadow_controller.py
+++ b/tests/core/services/test_shadow_controller.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, date
+
+import pytest
+
+from vprism.core.exceptions import DomainError
+from vprism.core.services.shadow import (
+    ShadowController,
+    ShadowPromoteGuard,
+    ShadowRunConfig,
+    ShadowRunSummary,
+    ShadowSamplingPolicy,
+)
+from vprism.core.services.shadow_diff import DiffEngine, ShadowRecord
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._current = datetime(2024, 1, 1, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        value = self._current
+        self._current += timedelta(milliseconds=50)
+        return value
+
+
+def _make_record(offset: int, close: float) -> ShadowRecord:
+    timestamp = datetime(2024, 1, 1 + offset, tzinfo=UTC)
+    return ShadowRecord(symbol="asset-1", market="cn", timestamp=timestamp, close=close)
+
+
+def _primary_executor(_: ShadowRunConfig) -> tuple[ShadowRecord, ...]:
+    return (
+        _make_record(0, 10.0),
+        _make_record(1, 10.5),
+    )
+
+
+def _candidate_executor(_: ShadowRunConfig) -> tuple[ShadowRecord, ...]:
+    return (
+        _make_record(0, 10.1),
+        _make_record(1, 10.45),
+    )
+
+
+def test_shadow_controller_run_waits_and_persists() -> None:
+    clock = FakeClock()
+    summaries: list[ShadowRunSummary] = []
+    controller = ShadowController(
+        _primary_executor,
+        _candidate_executor,
+        diff_engine=DiffEngine(),
+        sampling_policy=ShadowSamplingPolicy(default_sample_percent=100.0),
+        run_writer=summaries.append,
+        promote_guard=ShadowPromoteGuard(required_passes=2),
+        clock=clock,
+    )
+
+    config = ShadowRunConfig(
+        asset="asset-1",
+        markets=("cn",),
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 5),
+        sample_percent=100.0,
+    )
+
+    result = controller.run(config, wait_for_shadow=True)
+
+    assert result.sampled is True
+    assert result.summary is not None
+    assert result.diff is not None
+    assert summaries and summaries[0].run_id == result.run_id
+    state = controller.state()
+    assert state.consecutive_passes == 1
+    assert state.ready_for_promote is False
+
+
+def test_shadow_controller_handles_non_sampled_runs() -> None:
+    controller = ShadowController(
+        _primary_executor,
+        _candidate_executor,
+        diff_engine=DiffEngine(),
+        sampling_policy=ShadowSamplingPolicy(default_sample_percent=0.0),
+        promote_guard=ShadowPromoteGuard(required_passes=1),
+    )
+
+    config = ShadowRunConfig(
+        asset="asset-2",
+        markets=("us",),
+        start=date(2024, 2, 1),
+        end=date(2024, 2, 2),
+        sample_percent=0.0,
+    )
+
+    result = controller.run(config, wait_for_shadow=True)
+
+    assert result.sampled is False
+    assert result.summary is not None
+    assert result.diff is None
+
+
+def test_shadow_controller_async_completion_and_promote_guard() -> None:
+    clock = FakeClock()
+    summaries: list[ShadowRunSummary] = []
+    guard = ShadowPromoteGuard(required_passes=2)
+    controller = ShadowController(
+        _primary_executor,
+        _candidate_executor,
+        diff_engine=DiffEngine(),
+        sampling_policy=ShadowSamplingPolicy(default_sample_percent=100.0),
+        run_writer=summaries.append,
+        promote_guard=guard,
+        clock=clock,
+    )
+
+    config = ShadowRunConfig(
+        asset="asset-3",
+        markets=("cn",),
+        start=date(2024, 3, 1),
+        end=date(2024, 3, 2),
+        sample_percent=100.0,
+    )
+
+    result = controller.run(config, wait_for_shadow=False)
+
+    assert result.summary is None
+    controller.wait_for_run(result.run_id)
+    assert summaries and summaries[0].run_id == result.run_id
+
+    with pytest.raises(DomainError):
+        controller.promote()
+
+    controller.promote(force=True)
+    assert controller.state().active_mode == "candidate"
+    controller.rollback()
+    assert controller.state().active_mode == "primary"

--- a/tests/core/services/test_shadow_diff_engine.py
+++ b/tests/core/services/test_shadow_diff_engine.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from vprism.core.services.shadow_diff import (
+    DiffEngine,
+    ShadowDiffResult,
+    ShadowDiffStatus,
+    ShadowRecord,
+)
+
+
+def _record(ts: tuple[int, int, int], close: float) -> ShadowRecord:
+    return ShadowRecord(
+        symbol="asset-1",
+        market="cn",
+        timestamp=datetime(*ts, tzinfo=UTC),
+        close=close,
+    )
+
+
+def test_diff_engine_computes_statistics() -> None:
+    engine = DiffEngine()
+    primary = (
+        _record((2024, 1, 1, 0, 0, 0), 10.0),
+        _record((2024, 1, 2, 0, 0, 0), 12.0),
+        _record((2024, 1, 3, 0, 0, 0), 11.5),
+    )
+    candidate = (
+        _record((2024, 1, 1, 0, 0, 0), 10.1),
+        _record((2024, 1, 2, 0, 0, 0), 12.12),
+        _record((2024, 1, 3, 0, 0, 0), 11.46),
+    )
+
+    result = engine.compare(primary, candidate)
+
+    assert isinstance(result, ShadowDiffResult)
+    assert result.status is ShadowDiffStatus.PASS
+    assert result.row_diff_pct == pytest.approx(0.0)
+    assert result.gap_ratio == pytest.approx(0.0)
+    assert result.price_diff_bp_p95 == pytest.approx(100.0, abs=1e-3)
+    assert result.price_diff_bp_mean == pytest.approx(78.26, rel=1e-3)
+
+
+def test_diff_engine_flags_failures() -> None:
+    engine = DiffEngine()
+    primary = (
+        _record((2024, 1, 1, 0, 0, 0), 10.0),
+        _record((2024, 1, 2, 0, 0, 0), 11.0),
+    )
+    candidate = (
+        _record((2024, 1, 1, 0, 0, 0), 10.7),
+    )
+
+    result = engine.compare(primary, candidate)
+
+    assert result.status is ShadowDiffStatus.FAIL
+    assert result.row_diff_pct == pytest.approx(0.5)
+    assert result.gap_ratio == pytest.approx(0.5)
+    assert result.price_diff_bp_p95 >= 25.0

--- a/tests/core/services/test_shadow_persistence.py
+++ b/tests/core/services/test_shadow_persistence.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import duckdb
+import pytest
+from datetime import UTC, datetime, date
+
+from vprism.core.data import schema
+from vprism.core.services.shadow import (
+    DuckDBShadowRunWriter,
+    ShadowDiffStatus,
+    ShadowRunSummary,
+)
+
+
+def test_shadow_run_writer_persists_summary() -> None:
+    conn = duckdb.connect(database=":memory:")
+    schema.ensure_shadow_tables(conn)
+
+    writer = DuckDBShadowRunWriter(conn)
+    created_at = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+    summary = ShadowRunSummary(
+        run_id="run-1",
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 5),
+        asset="asset-1",
+        markets=("cn", "us"),
+        created_at=created_at,
+        row_diff_pct=0.1,
+        price_diff_bp_p95=12.0,
+        gap_ratio=0.02,
+        status=ShadowDiffStatus.WARN,
+        sample_percent=25.0,
+        lookback_days=30,
+        force_full_run=False,
+        primary_duration_ms=120.5,
+        candidate_duration_ms=135.2,
+    )
+
+    writer(summary)
+
+    rows = conn.execute("SELECT * FROM shadow_runs").fetchall()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row[0] == "run-1"
+    assert row[1] == summary.start
+    assert row[2] == summary.end
+    assert row[3] == "asset-1"
+    assert row[4] == "cn,us"
+    assert row[6] == pytest.approx(0.1)
+    assert row[7] == pytest.approx(12.0)
+    assert row[8] == pytest.approx(0.02)
+    assert row[9] == ShadowDiffStatus.WARN.value
+    assert row[10] == pytest.approx(25.0)
+    assert row[11] == 30
+    assert row[12] is False
+    assert row[13] == pytest.approx(120.5)
+    assert row[14] == pytest.approx(135.2)

--- a/tests/core/services/test_shadow_promote_guard.py
+++ b/tests/core/services/test_shadow_promote_guard.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from vprism.core.services.shadow import ShadowPromoteGuard
+from vprism.core.services.shadow_diff import ShadowDiffStatus
+
+
+def test_guard_requires_consecutive_passes() -> None:
+    guard = ShadowPromoteGuard(required_passes=3)
+    guard.observe(ShadowDiffStatus.PASS)
+    guard.observe(ShadowDiffStatus.PASS)
+    assert guard.ready is False
+    guard.observe(ShadowDiffStatus.PASS)
+    assert guard.ready is True
+    assert guard.consecutive_passes == 3
+
+
+def test_guard_resets_on_failure() -> None:
+    guard = ShadowPromoteGuard(required_passes=2)
+    guard.observe(ShadowDiffStatus.PASS)
+    guard.observe(ShadowDiffStatus.FAIL)
+    assert guard.ready is False
+    assert guard.consecutive_passes == 0
+
+
+def test_guard_configuration_override() -> None:
+    guard = ShadowPromoteGuard(required_passes=2)
+    guard.observe(ShadowDiffStatus.PASS)
+    guard.configure(required_passes=1)
+    assert guard.ready is False
+    guard.observe(ShadowDiffStatus.PASS)
+    assert guard.ready is True
+
+    with pytest.raises(ValueError):
+        guard.configure(0)

--- a/vprism/cli/main.py
+++ b/vprism/cli/main.py
@@ -13,6 +13,7 @@ from vprism.core.plugins import PluginLoader
 from .data import register as register_data_commands
 from .drift import register as register_drift_commands
 from .reconciliation import register as register_reconciliation_commands
+from .shadow import register as register_shadow_commands
 from .formatters import create_formatter
 from .symbol import register as register_symbol_commands
 
@@ -72,6 +73,7 @@ def create_app() -> typer.Typer:
     register_drift_commands(app)
     register_symbol_commands(app)
     register_reconciliation_commands(app)
+    register_shadow_commands(app)
     return app
 
 

--- a/vprism/cli/shadow.py
+++ b/vprism/cli/shadow.py
@@ -1,0 +1,188 @@
+"""Shadow deployment management commands."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import typer
+
+from vprism.core.exceptions import DomainError
+from vprism.core.services.shadow import (
+    ShadowController,
+    ShadowRunConfig,
+    ShadowRunSummary,
+    get_shadow_controller,
+)
+
+from .constants import SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .utils import emit_error, prepare_output
+
+
+shadow_app = typer.Typer(help="Manage shadow runs and promotion workflow.")
+
+SHADOW_RUN_COLUMNS = [
+    "run_id",
+    "status",
+    "row_diff_pct",
+    "price_diff_bp_p95",
+    "gap_ratio",
+    "sample_percent",
+    "lookback_days",
+    "force_full_run",
+    "primary_duration_ms",
+    "candidate_duration_ms",
+    "created_at",
+]
+
+
+def register(app: typer.Typer) -> None:
+    """Register shadow commands on the root CLI application."""
+
+    app.add_typer(shadow_app, name="shadow", help="Operate the shadow controller")
+
+
+def _parse_date(value: str, name: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - validated via typer error path
+        raise typer.BadParameter(f"Invalid date format for {name}. Use YYYY-MM-DD.") from exc
+
+
+@shadow_app.command("run")
+def run_command(
+    ctx: typer.Context,
+    asset: str = typer.Argument(..., help="Asset identifier to execute shadow run for."),
+    start: str = typer.Option(..., help="Inclusive start date (YYYY-MM-DD)."),
+    end: str = typer.Option(..., help="Inclusive end date (YYYY-MM-DD)."),
+    market: list[str] = typer.Option(
+        ["cn"],
+        "--market",
+        "-m",
+        help="Market codes to include. Multiple options allowed.",
+    ),
+    sample_percent: float = typer.Option(100.0, help="Sampling percentage for this run."),
+    lookback_days: int = typer.Option(30, help="Lookback window in days."),
+    force_full_run: bool = typer.Option(False, help="Force full run irrespective of sampling."),
+    wait: bool = typer.Option(True, help="Wait for diff completion before returning."),
+) -> None:
+    """Trigger a shadow run and render the resulting metrics."""
+
+    controller = _resolve_controller()
+    formatter, stream, stack, _ = prepare_output(ctx)
+
+    run_config = ShadowRunConfig(
+        asset=asset,
+        markets=tuple(market) if market else ("cn",),
+        start=_parse_date(start, "start"),
+        end=_parse_date(end, "end"),
+        sample_percent=sample_percent,
+        lookback_days=lookback_days,
+        force_full_run=force_full_run,
+    )
+
+    result = controller.run(run_config, wait_for_shadow=wait)
+    summary = result.summary
+    if summary is None:
+        summary = controller.wait_for_run(result.run_id)
+    if summary is None:
+        stack.close()
+        typer.echo("Shadow run dispatched.")
+        return
+
+    try:
+        formatter.render([
+            _summary_to_row(summary),
+        ], stream=stream, columns=SHADOW_RUN_COLUMNS)
+    finally:
+        stack.close()
+
+
+@shadow_app.command("status")
+def status_command(ctx: typer.Context) -> None:
+    """Display current controller state and last run metrics."""
+
+    controller = _resolve_controller()
+    state = controller.state()
+    formatter, stream, stack, _ = prepare_output(ctx)
+    try:
+        rows = []
+        if state.last_summary is not None:
+            rows.append(_summary_to_row(state.last_summary))
+        formatter.render(rows, stream=stream, columns=SHADOW_RUN_COLUMNS)
+    finally:
+        stack.close()
+
+    typer.echo(f"active_mode={state.active_mode}")
+    typer.echo(f"ready_for_promote={state.ready_for_promote}")
+    typer.echo(f"consecutive_passes={state.consecutive_passes}")
+
+
+@shadow_app.command("promote")
+def promote_command(
+    force: bool = typer.Option(False, "--force", help="Bypass readiness guard."),
+) -> None:
+    """Promote the shadow path to active production."""
+
+    controller = _resolve_controller()
+    try:
+        controller.promote(force=force)
+    except DomainError as exc:
+        emit_error(exc.message, exc.error_code, details=exc.details)
+        raise typer.Exit(code=VALIDATION_EXIT_CODE) from exc
+
+    typer.echo("Shadow path promoted.")
+
+
+@shadow_app.command("rollback")
+def rollback_command() -> None:
+    """Rollback to the primary path."""
+
+    controller = _resolve_controller()
+    controller.rollback()
+    typer.echo("Shadow path rolled back.")
+
+
+@shadow_app.command("diff")
+def diff_command(ctx: typer.Context) -> None:
+    """Render the latest diff metrics if available."""
+
+    controller = _resolve_controller()
+    state = controller.state()
+    if state.last_summary is None:
+        typer.echo("No shadow runs recorded yet.")
+        return
+
+    formatter, stream, stack, _ = prepare_output(ctx)
+    try:
+        formatter.render([
+            _summary_to_row(state.last_summary),
+        ], stream=stream, columns=SHADOW_RUN_COLUMNS)
+    finally:
+        stack.close()
+
+
+def _summary_to_row(summary: ShadowRunSummary) -> dict[str, object]:
+    return {
+        "run_id": summary.run_id,
+        "status": summary.status.value,
+        "row_diff_pct": summary.row_diff_pct,
+        "price_diff_bp_p95": summary.price_diff_bp_p95,
+        "gap_ratio": summary.gap_ratio,
+        "sample_percent": summary.sample_percent,
+        "lookback_days": summary.lookback_days,
+        "force_full_run": summary.force_full_run,
+        "primary_duration_ms": summary.primary_duration_ms,
+        "candidate_duration_ms": summary.candidate_duration_ms,
+        "created_at": summary.created_at.isoformat(),
+    }
+
+
+def _resolve_controller() -> ShadowController:
+    controller = get_shadow_controller()
+    if controller is None:  # pragma: no cover - defensive
+        emit_error("Shadow controller not configured", "SHADOW_NOT_CONFIGURED")
+        raise typer.Exit(code=SYSTEM_EXIT_CODE)
+    return controller
+
+
+__all__ = ["SHADOW_RUN_COLUMNS", "diff_command", "promote_command", "register", "rollback_command", "run_command", "status_command"]

--- a/vprism/core/data/schema.py
+++ b/vprism/core/data/schema.py
@@ -188,6 +188,29 @@ RECONCILIATION_DIFFS_TABLE = TableSchema(
 )
 
 
+vprism_shadow_runs_table = TableSchema(
+    name="shadow_runs",
+    columns=(
+        ColumnDef("run_id", "VARCHAR", ("NOT NULL",)),
+        ColumnDef('"start"', "DATE", ("NOT NULL",)),
+        ColumnDef('"end"', "DATE", ("NOT NULL",)),
+        ColumnDef("asset", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("markets", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("created_at", "TIMESTAMP", ("NOT NULL",)),
+        ColumnDef("row_diff_pct", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("price_diff_bp_p95", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("gap_ratio", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("status", "VARCHAR", ("NOT NULL",)),
+        ColumnDef("sample_percent", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("lookback_days", "INTEGER", ("NOT NULL",)),
+        ColumnDef("force_full_run", "BOOLEAN", ("NOT NULL",)),
+        ColumnDef("primary_duration_ms", "DOUBLE", ("NOT NULL",)),
+        ColumnDef("candidate_duration_ms", "DOUBLE", ("NOT NULL",)),
+    ),
+    primary_key=("run_id",),
+)
+
+
 def baseline_tables() -> Sequence[TableSchema]:
     """Return the schemas that compose the PRD-0 baseline."""
 
@@ -326,4 +349,24 @@ def create_reconciliation_ddl() -> Iterable[str]:
     """Yield CREATE TABLE statements for reconciliation storage."""
 
     for table in reconciliation_tables():
+        yield table.create_ddl()
+
+
+def shadow_tables() -> Sequence[TableSchema]:
+    """Return the schemas used for shadow run persistence."""
+
+    return (vprism_shadow_runs_table,)
+
+
+def ensure_shadow_tables(conn: DuckDBPyConnection) -> None:
+    """Create the shadow tables on the provided connection."""
+
+    for table in shadow_tables():
+        table.ensure(conn)
+
+
+def create_shadow_ddl() -> Iterable[str]:
+    """Yield CREATE TABLE statements for shadow persistence."""
+
+    for table in shadow_tables():
         yield table.create_ddl()

--- a/vprism/core/monitoring/__init__.py
+++ b/vprism/core/monitoring/__init__.py
@@ -7,6 +7,11 @@ from vprism.core.monitoring.health import (
     get_health_checker,
 )
 from vprism.core.monitoring.logging import PerformanceLogger, StructuredLogger, bind
+from vprism.core.monitoring.performance import (
+    SlowQueryLogger,
+    SlowQueryObservation,
+    SlowQueryThresholds,
+)
 from vprism.core.monitoring.metrics import (
     MetricsCollector,
     configure_metrics_collector,
@@ -21,6 +26,9 @@ __all__ = [
     "StructuredLogger",
     "PerformanceLogger",
     "bind",
+    "SlowQueryLogger",
+    "SlowQueryObservation",
+    "SlowQueryThresholds",
     "MetricsCollector",
     "get_metrics_collector",
     "configure_metrics_collector",

--- a/vprism/core/monitoring/performance.py
+++ b/vprism/core/monitoring/performance.py
@@ -1,0 +1,100 @@
+"""Performance monitoring utilities for query latency thresholds."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any, Iterator
+
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class SlowQueryThresholds:
+    """Configuration describing slow query alert thresholds."""
+
+    p95_ms: float = 500.0
+
+    def is_slow(self, duration_ms: float) -> bool:
+        """Return ``True`` when ``duration_ms`` exceeds the configured threshold."""
+
+        return duration_ms >= self.p95_ms
+
+
+@dataclass(frozen=True)
+class SlowQueryObservation:
+    """Represents a single slow query latency observation."""
+
+    operation: str
+    duration_ms: float
+    threshold_ms: float
+    attributes: Mapping[str, Any]
+    is_slow: bool
+
+
+class SlowQueryLogger:
+    """Monitor query latency and emit warnings when crossing thresholds."""
+
+    def __init__(
+        self,
+        *,
+        thresholds: SlowQueryThresholds | None = None,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        self._thresholds = thresholds or SlowQueryThresholds()
+        self._time_source = time_source or perf_counter
+
+    @contextmanager
+    def track(
+        self,
+        operation: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[None]:
+        """Context manager measuring a block and logging slow executions."""
+
+        start = self._time_source()
+        try:
+            yield
+        finally:
+            duration_ms = (self._time_source() - start) * 1000.0
+            self.observe(operation, duration_ms, attributes=attributes)
+
+    def observe(
+        self,
+        operation: str,
+        duration_ms: float,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> SlowQueryObservation:
+        """Record an explicit latency observation and emit warnings when slow."""
+
+        payload = dict(attributes or {})
+        is_slow = self._thresholds.is_slow(duration_ms)
+        observation = SlowQueryObservation(
+            operation=operation,
+            duration_ms=duration_ms,
+            threshold_ms=self._thresholds.p95_ms,
+            attributes=payload,
+            is_slow=is_slow,
+        )
+        if is_slow:
+            logger.warning(
+                f"slow query detected for {operation}",
+                extra={
+                    "operation": operation,
+                    "duration_ms": round(duration_ms, 3),
+                    "threshold_ms": self._thresholds.p95_ms,
+                    **payload,
+                },
+            )
+        return observation
+
+
+__all__ = [
+    "SlowQueryLogger",
+    "SlowQueryObservation",
+    "SlowQueryThresholds",
+]

--- a/vprism/core/services/shadow.py
+++ b/vprism/core/services/shadow.py
@@ -1,0 +1,426 @@
+"""Shadow controller orchestrating dual-path execution and persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from threading import Lock
+from uuid import uuid4
+
+from vprism.core.data.schema import vprism_shadow_runs_table
+from vprism.core.exceptions import DomainError
+from vprism.core.exceptions.codes import ErrorCode
+
+from .shadow_diff import DiffEngine, ShadowDiffResult, ShadowDiffStatus, ShadowRecord
+
+try:  # pragma: no cover - duckdb is optional during import time
+    from duckdb import DuckDBPyConnection
+except Exception:  # pragma: no cover
+    DuckDBPyConnection = "DuckDBPyConnection"  # type: ignore[misc,assignment]
+
+
+ShadowExecutor = Callable[["ShadowRunConfig"], Sequence[ShadowRecord]]
+ShadowRunWriter = Callable[["ShadowRunSummary"], None]
+Clock = Callable[[], datetime]
+
+
+@dataclass(frozen=True)
+class ShadowRunConfig:
+    """Parameters describing a single shadow comparison run."""
+
+    asset: str
+    markets: Sequence[str]
+    start: date
+    end: date
+    sample_percent: float = 100.0
+    lookback_days: int = 30
+    force_full_run: bool = False
+    run_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "markets", tuple(self.markets))
+
+
+@dataclass(frozen=True)
+class ShadowRunSummary:
+    """Persisted metrics summarising a shadow run."""
+
+    run_id: str
+    start: date
+    end: date
+    asset: str
+    markets: tuple[str, ...]
+    created_at: datetime
+    row_diff_pct: float
+    price_diff_bp_p95: float
+    gap_ratio: float
+    status: ShadowDiffStatus
+    sample_percent: float
+    lookback_days: int
+    force_full_run: bool
+    primary_duration_ms: float
+    candidate_duration_ms: float
+
+
+@dataclass(frozen=True)
+class ShadowRunResult:
+    """Return value for :meth:`ShadowController.run`."""
+
+    run_id: str
+    sampled: bool
+    primary_result: Sequence[ShadowRecord]
+    summary: ShadowRunSummary | None
+    diff: ShadowDiffResult | None
+
+
+@dataclass(frozen=True)
+class ShadowControllerState:
+    """Snapshot describing controller state for CLI consumption."""
+
+    active_mode: str
+    ready_for_promote: bool
+    consecutive_passes: int
+    last_summary: ShadowRunSummary | None
+
+
+class ShadowSamplingPolicy:
+    """Determine when requests should execute in shadow mode."""
+
+    def __init__(
+        self,
+        *,
+        default_sample_percent: float = 10.0,
+        random_func: Callable[[], float] | None = None,
+    ) -> None:
+        self._default = max(0.0, min(default_sample_percent, 100.0))
+        self._random = random_func or __import__("random").random
+
+    def should_sample(self, config: ShadowRunConfig) -> bool:
+        if config.force_full_run:
+            return True
+        percent = max(0.0, min(config.sample_percent, 100.0))
+        if percent >= 100.0:
+            return True
+        if percent <= 0.0:
+            return False
+        return self._random() * 100.0 < percent
+
+
+class ShadowPromoteGuard:
+    """Track consecutive PASS runs before allowing promotion."""
+
+    def __init__(self, required_passes: int = 3) -> None:
+        if required_passes < 1:
+            msg = "required_passes must be at least one"
+            raise ValueError(msg)
+        self._required = required_passes
+        self._consecutive = 0
+        self._ready = False
+        self._lock = Lock()
+
+    def observe(self, status: ShadowDiffStatus) -> None:
+        with self._lock:
+            if status is ShadowDiffStatus.PASS:
+                self._consecutive += 1
+            else:
+                self._consecutive = 0
+            self._ready = self._consecutive >= self._required
+
+    def configure(self, required_passes: int) -> None:
+        if required_passes < 1:
+            msg = "required_passes must be at least one"
+            raise ValueError(msg)
+        with self._lock:
+            self._required = required_passes
+            self._consecutive = 0
+            self._ready = False
+
+    @property
+    def ready(self) -> bool:
+        with self._lock:
+            return self._ready
+
+    @property
+    def consecutive_passes(self) -> int:
+        with self._lock:
+            return self._consecutive
+
+
+class DuckDBShadowRunWriter:
+    """Persist :class:`ShadowRunSummary` rows into DuckDB."""
+
+    def __init__(self, connection: DuckDBPyConnection) -> None:
+        self._connection = connection
+        vprism_shadow_runs_table.ensure(connection)
+
+    def __call__(self, summary: ShadowRunSummary) -> None:
+        markets = ",".join(summary.markets)
+        self._connection.execute(
+            """
+            INSERT INTO shadow_runs
+            (run_id, "start", "end", asset, markets, created_at, row_diff_pct,
+             price_diff_bp_p95, gap_ratio, status, sample_percent, lookback_days, force_full_run,
+             primary_duration_ms, candidate_duration_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                summary.run_id,
+                summary.start,
+                summary.end,
+                summary.asset,
+                markets,
+                summary.created_at,
+                summary.row_diff_pct,
+                summary.price_diff_bp_p95,
+                summary.gap_ratio,
+                summary.status.value,
+                summary.sample_percent,
+                summary.lookback_days,
+                summary.force_full_run,
+                summary.primary_duration_ms,
+                summary.candidate_duration_ms,
+            ],
+        )
+
+
+class ShadowController:
+    """Coordinate dual-path execution, diffing, and persistence."""
+
+    def __init__(
+        self,
+        primary_executor: ShadowExecutor,
+        candidate_executor: ShadowExecutor,
+        *,
+        diff_engine: DiffEngine | None = None,
+        sampling_policy: ShadowSamplingPolicy | None = None,
+        run_writer: ShadowRunWriter | None = None,
+        promote_guard: ShadowPromoteGuard | None = None,
+        executor: Executor | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._baseline_executor = primary_executor
+        self._candidate_executor = candidate_executor
+        self._diff_engine = diff_engine or DiffEngine()
+        self._sampling_policy = sampling_policy or ShadowSamplingPolicy()
+        self._run_writer = run_writer
+        self._promote_guard = promote_guard or ShadowPromoteGuard()
+        self._executor = executor or ThreadPoolExecutor(max_workers=2)
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._lock = Lock()
+        self._last_summary: ShadowRunSummary | None = None
+        self._pending_runs: dict[str, Future[ShadowDiffResult | None]] = {}
+        self._active_mode = "primary"
+
+    def run(
+        self,
+        config: ShadowRunConfig,
+        *,
+        wait_for_shadow: bool = False,
+    ) -> ShadowRunResult:
+        run_id = config.run_id or uuid4().hex
+        active_executor = self._resolve_active_executor()
+        shadow_executor = self._resolve_shadow_executor()
+
+        primary_start = self._clock()
+        primary_result = tuple(active_executor(config))
+        primary_duration_ms = (self._clock() - primary_start).total_seconds() * 1000.0
+
+        should_sample = self._sampling_policy.should_sample(config)
+        diff_result: ShadowDiffResult | None = None
+        summary: ShadowRunSummary | None = None
+
+        if should_sample:
+            if wait_for_shadow:
+                candidate_result, candidate_duration_ms = self._execute_shadow(shadow_executor, config)
+                diff_result, summary = self._finalize_run(
+                    run_id,
+                    config,
+                    primary_result,
+                    candidate_result,
+                    primary_duration_ms,
+                    candidate_duration_ms,
+                )
+            else:
+                future = self._executor.submit(
+                    self._async_shadow,
+                    run_id,
+                    config,
+                    primary_result,
+                    primary_duration_ms,
+                    shadow_executor,
+                )
+                with self._lock:
+                    self._pending_runs[run_id] = future
+        else:
+            summary = self._build_summary(
+                run_id,
+                config,
+                primary_duration_ms=primary_duration_ms,
+                candidate_duration_ms=0.0,
+                diff_result=None,
+            )
+            self._update_state(summary, diff_result=None)
+
+        return ShadowRunResult(
+            run_id=run_id,
+            sampled=should_sample,
+            primary_result=primary_result,
+            summary=summary if summary is not None else None,
+            diff=diff_result,
+        )
+
+    def wait_for_run(self, run_id: str, timeout: float | None = None) -> ShadowRunSummary | None:
+        with self._lock:
+            future = self._pending_runs.get(run_id)
+        if future is None:
+            return None
+        future.result(timeout)
+        with self._lock:
+            return self._last_summary
+
+    def promote(self, *, force: bool = False) -> None:
+        if not force and not self._promote_guard.ready:
+            raise DomainError(
+                "Shadow controller is not ready for promotion.",
+                ErrorCode.VALIDATION,
+                layer="shadow.promote",
+            )
+        self._active_mode = "candidate"
+
+    def rollback(self) -> None:
+        self._active_mode = "primary"
+
+    def state(self) -> ShadowControllerState:
+        with self._lock:
+            summary = self._last_summary
+        return ShadowControllerState(
+            active_mode=self._active_mode,
+            ready_for_promote=self._promote_guard.ready,
+            consecutive_passes=self._promote_guard.consecutive_passes,
+            last_summary=summary,
+        )
+
+    def _async_shadow(
+        self,
+        run_id: str,
+        config: ShadowRunConfig,
+        primary_result: Sequence[ShadowRecord],
+        primary_duration_ms: float,
+        shadow_executor: ShadowExecutor,
+    ) -> ShadowDiffResult | None:
+        candidate_result, candidate_duration_ms = self._execute_shadow(shadow_executor, config)
+        diff_result, summary = self._finalize_run(
+            run_id,
+            config,
+            primary_result,
+            candidate_result,
+            primary_duration_ms,
+            candidate_duration_ms,
+        )
+        with self._lock:
+            self._pending_runs.pop(run_id, None)
+        return diff_result
+
+    def _execute_shadow(
+        self,
+        executor: ShadowExecutor,
+        config: ShadowRunConfig,
+    ) -> tuple[tuple[ShadowRecord, ...], float]:
+        start_time = self._clock()
+        result = tuple(executor(config))
+        duration_ms = (self._clock() - start_time).total_seconds() * 1000.0
+        return result, duration_ms
+
+    def _finalize_run(
+        self,
+        run_id: str,
+        config: ShadowRunConfig,
+        primary_result: Sequence[ShadowRecord],
+        candidate_result: Sequence[ShadowRecord],
+        primary_duration_ms: float,
+        candidate_duration_ms: float,
+    ) -> tuple[ShadowDiffResult, ShadowRunSummary]:
+        diff_result = self._diff_engine.compare(primary_result, candidate_result)
+        summary = self._build_summary(
+            run_id,
+            config,
+            primary_duration_ms=primary_duration_ms,
+            candidate_duration_ms=candidate_duration_ms,
+            diff_result=diff_result,
+        )
+        self._update_state(summary, diff_result=diff_result)
+        return diff_result, summary
+
+    def _build_summary(
+        self,
+        run_id: str,
+        config: ShadowRunConfig,
+        *,
+        primary_duration_ms: float,
+        candidate_duration_ms: float,
+        diff_result: ShadowDiffResult | None,
+    ) -> ShadowRunSummary:
+        status = diff_result.status if diff_result else ShadowDiffStatus.PASS
+        return ShadowRunSummary(
+            run_id=run_id,
+            start=config.start,
+            end=config.end,
+            asset=config.asset,
+            markets=tuple(config.markets),
+            created_at=self._clock(),
+            row_diff_pct=diff_result.row_diff_pct if diff_result else 0.0,
+            price_diff_bp_p95=diff_result.price_diff_bp_p95 if diff_result else 0.0,
+            gap_ratio=diff_result.gap_ratio if diff_result else 0.0,
+            status=status,
+            sample_percent=max(0.0, min(config.sample_percent, 100.0)),
+            lookback_days=config.lookback_days,
+            force_full_run=config.force_full_run,
+            primary_duration_ms=primary_duration_ms,
+            candidate_duration_ms=candidate_duration_ms,
+        )
+
+    def _update_state(
+        self,
+        summary: ShadowRunSummary,
+        *,
+        diff_result: ShadowDiffResult | None,
+    ) -> None:
+        with self._lock:
+            self._last_summary = summary
+        if diff_result is not None:
+            self._promote_guard.observe(diff_result.status)
+        if self._run_writer and diff_result is not None:
+            self._run_writer(summary)
+
+    def _resolve_active_executor(self) -> ShadowExecutor:
+        if self._active_mode == "candidate":
+            return self._candidate_executor
+        return self._baseline_executor
+
+    def _resolve_shadow_executor(self) -> ShadowExecutor:
+        if self._active_mode == "candidate":
+            return self._baseline_executor
+        return self._candidate_executor
+
+
+def get_shadow_controller() -> ShadowController:
+    """Factory method intended for dependency injection."""
+
+    raise RuntimeError("Shadow controller is not configured")
+
+
+__all__ = [
+    "Clock",
+    "DuckDBShadowRunWriter",
+    "ShadowController",
+    "ShadowControllerState",
+    "ShadowExecutor",
+    "ShadowPromoteGuard",
+    "ShadowRunConfig",
+    "ShadowRunResult",
+    "ShadowRunSummary",
+    "ShadowSamplingPolicy",
+    "get_shadow_controller",
+]

--- a/vprism/core/services/shadow_diff.py
+++ b/vprism/core/services/shadow_diff.py
@@ -1,0 +1,159 @@
+"""Shadow diff computation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from math import ceil
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class ShadowRecord:
+    """Normalized representation of a row returned by a query path."""
+
+    symbol: str
+    market: str
+    timestamp: datetime
+    close: float
+
+    def key(self) -> tuple[str, str, datetime]:
+        return self.symbol, self.market, self.timestamp
+
+
+class ShadowDiffStatus(str, Enum):
+    """Classification of diff health."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class ShadowDiffThresholds:
+    """Thresholds controlling diff status classification."""
+
+    row_diff_warn: float = 0.02
+    row_diff_fail: float = 0.1
+    price_diff_bp_p95_warn: float = 150.0
+    price_diff_bp_p95_fail: float = 300.0
+    gap_ratio_warn: float = 0.02
+    gap_ratio_fail: float = 0.1
+
+
+@dataclass(frozen=True)
+class ShadowDiffResult:
+    """Aggregated diff metrics for a shadow comparison."""
+
+    row_diff_pct: float
+    price_diff_bp_mean: float
+    price_diff_bp_p95: float
+    gap_ratio: float
+    status: ShadowDiffStatus
+
+
+class DiffEngine:
+    """Compute metric deltas between two query results."""
+
+    def __init__(self, thresholds: ShadowDiffThresholds | None = None) -> None:
+        self._thresholds = thresholds or ShadowDiffThresholds()
+
+    def compare(
+        self,
+        primary_rows: Sequence[ShadowRecord],
+        candidate_rows: Sequence[ShadowRecord],
+    ) -> ShadowDiffResult:
+        primary_map = {record.key(): record for record in primary_rows}
+        candidate_map = {record.key(): record for record in candidate_rows}
+
+        row_diff_pct = self._compute_row_diff_pct(primary_map, candidate_map)
+        gap_ratio = self._compute_gap_ratio(primary_map, candidate_map)
+        bp_diffs = list(self._iter_basis_point_diffs(primary_map, candidate_map))
+        price_diff_bp_mean = sum(bp_diffs) / len(bp_diffs) if bp_diffs else 0.0
+        price_diff_bp_p95 = self._percentile(bp_diffs, 95)
+
+        status = self._classify(row_diff_pct, price_diff_bp_p95, gap_ratio)
+        return ShadowDiffResult(
+            row_diff_pct=row_diff_pct,
+            price_diff_bp_mean=price_diff_bp_mean,
+            price_diff_bp_p95=price_diff_bp_p95,
+            gap_ratio=gap_ratio,
+            status=status,
+        )
+
+    def _classify(
+        self,
+        row_diff_pct: float,
+        price_diff_bp_p95: float,
+        gap_ratio: float,
+    ) -> ShadowDiffStatus:
+        thresholds = self._thresholds
+        if (
+            row_diff_pct >= thresholds.row_diff_fail
+            or price_diff_bp_p95 >= thresholds.price_diff_bp_p95_fail
+            or gap_ratio >= thresholds.gap_ratio_fail
+        ):
+            return ShadowDiffStatus.FAIL
+        if (
+            row_diff_pct >= thresholds.row_diff_warn
+            or price_diff_bp_p95 >= thresholds.price_diff_bp_p95_warn
+            or gap_ratio >= thresholds.gap_ratio_warn
+        ):
+            return ShadowDiffStatus.WARN
+        return ShadowDiffStatus.PASS
+
+    @staticmethod
+    def _compute_row_diff_pct(
+        primary_map: dict[tuple[str, str, datetime], ShadowRecord],
+        candidate_map: dict[tuple[str, str, datetime], ShadowRecord],
+    ) -> float:
+        primary_count = len(primary_map)
+        candidate_count = len(candidate_map)
+        if primary_count == 0:
+            return 0.0 if candidate_count == 0 else 1.0
+        return abs(primary_count - candidate_count) / primary_count
+
+    @staticmethod
+    def _compute_gap_ratio(
+        primary_map: dict[tuple[str, str, datetime], ShadowRecord],
+        candidate_map: dict[tuple[str, str, datetime], ShadowRecord],
+    ) -> float:
+        primary_count = len(primary_map)
+        if primary_count == 0:
+            return 0.0
+        missing = sum(1 for key in primary_map if key not in candidate_map)
+        return missing / primary_count
+
+    @staticmethod
+    def _iter_basis_point_diffs(
+        primary_map: dict[tuple[str, str, datetime], ShadowRecord],
+        candidate_map: dict[tuple[str, str, datetime], ShadowRecord],
+    ) -> Iterable[float]:
+        for key, primary_record in primary_map.items():
+            candidate_record = candidate_map.get(key)
+            if candidate_record is None:
+                continue
+            if primary_record.close == 0:
+                yield 0.0
+                continue
+            diff_ratio = abs(candidate_record.close - primary_record.close) / abs(primary_record.close)
+            yield diff_ratio * 10000
+
+    @staticmethod
+    def _percentile(values: Sequence[float], percentile: int) -> float:
+        if not values:
+            return 0.0
+        sorted_values = sorted(values)
+        rank = ceil((percentile / 100) * len(sorted_values))
+        index = min(max(rank - 1, 0), len(sorted_values) - 1)
+        return sorted_values[index]
+
+
+__all__ = [
+    "DiffEngine",
+    "ShadowDiffResult",
+    "ShadowDiffStatus",
+    "ShadowDiffThresholds",
+    "ShadowRecord",
+]


### PR DESCRIPTION
## Summary
- add a SlowQueryLogger utility for slow query monitoring
- implement the shadow controller, diff engine, persistence, and CLI commands for shadow operations
- extend the DuckDB schema with a shadow_runs table and track promotion readiness via the guard

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68de850f5c28832d9508d5987d053724