### PR TITLE
Add CLI quality metrics report command

### DIFF
--- a/tests/cli/test_quality_report_command.py
+++ b/tests/cli/test_quality_report_command.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from datetime import date, datetime
+
+import duckdb
+import pytest
+from typer.testing import CliRunner
+
+from vprism.cli import quality as quality_module
+from vprism.cli.main import create_app
+from vprism.core.data.schema import vprism_quality_metrics_table
+
+
+class StubDuckDBFactory:
+    def __init__(self, connection: duckdb.DuckDBPyConnection) -> None:
+        self._connection = connection
+
+    @contextmanager
+    def connection(self) -> duckdb.DuckDBPyConnection:
+        yield self._connection
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def duckdb_connection(monkeypatch: pytest.MonkeyPatch) -> duckdb.DuckDBPyConnection:
+    connection = duckdb.connect(database=":memory:")
+    vprism_quality_metrics_table.ensure(connection)
+    monkeypatch.setattr(quality_module, "get_duckdb_factory", lambda: StubDuckDBFactory(connection))
+    yield connection
+    connection.close()
+
+
+def _insert_sample_metrics(connection: duckdb.DuckDBPyConnection) -> None:
+    connection.executemany(
+        """
+        INSERT INTO quality_metrics (date, market, supplier_symbol, metric, value, status, run_id, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                date(2024, 1, 5),
+                "cn",
+                "000001",
+                "gap_ratio",
+                0.0,
+                "OK",
+                "run-gap",
+                datetime(2024, 1, 6, 12, 0, 0),
+            ),
+            (
+                date(2024, 1, 5),
+                "cn",
+                "000002",
+                "duplicate_count",
+                2.0,
+                "WARN",
+                "run-dup",
+                datetime(2024, 1, 6, 12, 5, 0),
+            ),
+        ],
+    )
+
+
+def test_report_renders_table_output(runner: CliRunner, duckdb_connection: duckdb.DuckDBPyConnection) -> None:
+    _insert_sample_metrics(duckdb_connection)
+
+    app = create_app()
+    result = runner.invoke(app, ["quality", "report"])
+
+    assert result.exit_code == 0, result.output
+    assert "gap_ratio" in result.output
+    assert "duplicate_count" in result.output
+    assert "000001" in result.output
+    assert "run-gap" in result.output
+
+
+def test_report_renders_jsonl_output(runner: CliRunner, duckdb_connection: duckdb.DuckDBPyConnection) -> None:
+    _insert_sample_metrics(duckdb_connection)
+
+    app = create_app()
+    result = runner.invoke(app, ["--format", "jsonl", "quality", "report"])
+
+    assert result.exit_code == 0, result.output
+    payloads = [json.loads(line) for line in result.output.strip().splitlines()]
+    assert len(payloads) == 2
+    for payload in payloads:
+        assert {"metric", "value", "status", "run_id", "symbol"}.issubset(payload)
+    metrics = {payload["metric"] for payload in payloads}
+    assert metrics == {"gap_ratio", "duplicate_count"}
+
+
+def test_report_emits_error_when_no_rows(runner: CliRunner, duckdb_connection: duckdb.DuckDBPyConnection) -> None:
+    app = create_app()
+    result = runner.invoke(app, ["quality", "report"])
+
+    assert result.exit_code == 10
+    assert "QUALITY_METRICS_NOT_FOUND" in result.stderr

--- a/vprism/cli/main.py
+++ b/vprism/cli/main.py
@@ -12,9 +12,10 @@ from vprism.core.plugins import PluginLoader
 
 from .data import register as register_data_commands
 from .drift import register as register_drift_commands
+from .formatters import create_formatter
+from .quality import register as register_quality_commands
 from .reconciliation import register as register_reconciliation_commands
 from .shadow import register as register_shadow_commands
-from .formatters import create_formatter
 from .symbol import register as register_symbol_commands
 
 
@@ -71,6 +72,7 @@ def create_app() -> typer.Typer:
 
     register_data_commands(app)
     register_drift_commands(app)
+    register_quality_commands(app)
     register_symbol_commands(app)
     register_reconciliation_commands(app)
     register_shadow_commands(app)

--- a/vprism/cli/quality.py
+++ b/vprism/cli/quality.py
@@ -1,0 +1,208 @@
+"""Quality metric commands for the VPrism CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+
+from vprism.core.data.schema import (
+    VPrismQualityMetricStatus,
+    vprism_quality_metrics_table,
+)
+from vprism.core.data.storage.duckdb_factory import VPrismDuckDBFactory
+
+from .constants import SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .utils import emit_error, prepare_output
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from duckdb import DuckDBPyConnection
+
+
+QUALITY_COLUMNS = [
+    "date",
+    "market",
+    "symbol",
+    "metric",
+    "value",
+    "status",
+    "run_id",
+    "created_at",
+]
+
+quality_app = typer.Typer(help="Quality metric reports.")
+
+
+def register(app: typer.Typer) -> None:
+    """Register the quality command group on the provided application."""
+
+    app.add_typer(quality_app, name="quality", help="Inspect stored quality metrics")
+
+
+def get_duckdb_factory() -> VPrismDuckDBFactory:
+    """Factory hook for obtaining a DuckDB connection factory."""
+
+    return VPrismDuckDBFactory()
+
+
+@quality_app.command("report")
+def report_command(
+    ctx: typer.Context,
+    symbol: str | None = typer.Option(None, "--symbol", help="Filter by supplier symbol."),
+    market: str | None = typer.Option(None, "--market", help="Filter by market identifier."),
+    metric: str | None = typer.Option(None, "--metric", help="Filter by metric name."),
+    status: str | None = typer.Option(
+        None,
+        "--status",
+        help="Filter by metric status (OK, WARN, FAIL).",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        help="Maximum number of rows to return.",
+    ),
+) -> None:
+    """Render quality metrics stored in DuckDB."""
+
+    formatter, stream, stack, _ = prepare_output(ctx)
+    try:
+        normalized_status = _normalize_status(status)
+        if limit is not None and limit <= 0:
+            emit_error(
+                "Limit must be a positive integer.",
+                "INVALID_LIMIT",
+                details={"limit": limit},
+            )
+            raise typer.Exit(code=VALIDATION_EXIT_CODE)
+
+        factory = get_duckdb_factory()
+        with factory.connection() as connection:
+            vprism_quality_metrics_table.ensure(connection)
+            rows = _fetch_quality_metrics(
+                connection,
+                symbol=symbol,
+                market=market,
+                metric=metric,
+                status=normalized_status,
+                limit=limit,
+            )
+
+        if not rows:
+            filters = _build_filter_details(
+                symbol=symbol,
+                market=market,
+                metric=metric,
+                status=normalized_status,
+            )
+            emit_error(
+                "No quality metrics found for the provided filters.",
+                "QUALITY_METRICS_NOT_FOUND",
+                details=filters or None,
+            )
+            raise typer.Exit(code=VALIDATION_EXIT_CODE)
+
+        formatter.render(rows, stream=stream, columns=QUALITY_COLUMNS)
+    except typer.Exit:
+        raise
+    except Exception as error:  # pragma: no cover - defensive safeguard
+        emit_error(str(error), "QUALITY_METRIC_QUERY_ERROR")
+        raise typer.Exit(code=SYSTEM_EXIT_CODE) from error
+    finally:
+        stack.close()
+
+
+def _normalize_status(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().upper()
+    allowed = {item.value for item in VPrismQualityMetricStatus}
+    if normalized not in allowed:
+        emit_error(
+            f"Unsupported status '{value}'.",
+            "INVALID_STATUS",
+            details={"allowed": sorted(allowed)},
+        )
+        raise typer.Exit(code=VALIDATION_EXIT_CODE)
+    return normalized
+
+
+def _fetch_quality_metrics(
+    connection: "DuckDBPyConnection",
+    *,
+    symbol: str | None,
+    market: str | None,
+    metric: str | None,
+    status: str | None,
+    limit: int | None,
+) -> list[dict[str, object]]:
+    base_query = "SELECT date, market, supplier_symbol, metric, value, status, run_id, created_at FROM quality_metrics"
+    filters: list[str] = []
+    params: list[object] = []
+
+    if symbol:
+        filters.append("supplier_symbol = ?")
+        params.append(symbol)
+    if market:
+        filters.append("market = ?")
+        params.append(market)
+    if metric:
+        filters.append("metric = ?")
+        params.append(metric)
+    if status:
+        filters.append("status = ?")
+        params.append(status)
+
+    if filters:
+        base_query += " WHERE " + " AND ".join(filters)
+
+    base_query += " ORDER BY date DESC, created_at DESC"
+
+    if limit is not None:
+        base_query += " LIMIT ?"
+        params.append(limit)
+
+    cursor = connection.execute(base_query, params)
+    results = cursor.fetchall()
+    rows: list[dict[str, object]] = []
+    for row in results:
+        rows.append(
+            {
+                "date": row[0],
+                "market": row[1],
+                "symbol": row[2],
+                "metric": row[3],
+                "value": row[4],
+                "status": row[5],
+                "run_id": row[6],
+                "created_at": row[7],
+            }
+        )
+    return rows
+
+
+def _build_filter_details(
+    *,
+    symbol: str | None,
+    market: str | None,
+    metric: str | None,
+    status: str | None,
+) -> dict[str, object]:
+    details: dict[str, object] = {}
+    if symbol is not None:
+        details["symbol"] = symbol
+    if market is not None:
+        details["market"] = market
+    if metric is not None:
+        details["metric"] = metric
+    if status is not None:
+        details["status"] = status
+    return details
+
+
+__all__ = [
+    "QUALITY_COLUMNS",
+    "get_duckdb_factory",
+    "quality_app",
+    "register",
+    "report_command",
+]


### PR DESCRIPTION
## Summary
- add a new `quality report` CLI command that streams `quality_metrics` rows from DuckDB via `prepare_output`
- register the quality group with the main Typer app alongside existing command groups
- exercise the new command with table/JSONL output and missing-row error handling tests

## Testing
- uv run pytest tests/cli/test_quality_report_command.py

------
https://chatgpt.com/codex/tasks/task_e_68e622b498fc832db39b5e0b4ee3b12b