### PR TITLE
Refactor CLI error handling and add coverage

### DIFF
--- a/tests/cli/test_cli_error_handling.py
+++ b/tests/cli/test_cli_error_handling.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from vprism.cli.constants import (
+    DATA_QUALITY_EXIT_CODE,
+    PROVIDER_EXIT_CODE,
+    RECONCILE_EXIT_CODE,
+    SYSTEM_EXIT_CODE,
+    VALIDATION_EXIT_CODE,
+)
+from vprism.cli.errors import handle_cli_error
+from vprism.cli.main import app
+from vprism.core.exceptions.codes import ErrorCode
+from vprism.core.exceptions.domain import DomainError
+
+
+class DummyDomainError(DomainError):
+    def __init__(self, message: str, code: ErrorCode):
+        super().__init__(message, code=code, layer="cli-test")
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_exit"),
+    [
+        (ErrorCode.VALIDATION, VALIDATION_EXIT_CODE),
+        (ErrorCode.PROVIDER, PROVIDER_EXIT_CODE),
+        (ErrorCode.DATA_QUALITY, DATA_QUALITY_EXIT_CODE),
+        (ErrorCode.RECONCILE, RECONCILE_EXIT_CODE),
+        (ErrorCode.SYSTEM, SYSTEM_EXIT_CODE),
+    ],
+)
+def test_handle_cli_error_emits_payload_and_exit_code(
+    code: ErrorCode, expected_exit: int, capsys: pytest.CaptureFixture[str]
+) -> None:
+    error = DummyDomainError("boom", code)
+
+    exit_code = handle_cli_error(error)
+
+    assert exit_code == expected_exit
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err.strip())
+    assert payload["code"] == code.value
+    assert payload["message"] == "boom"
+    assert payload["details"]["layer"] == "cli-test"
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_exit"),
+    [
+        (ErrorCode.VALIDATION, VALIDATION_EXIT_CODE),
+        (ErrorCode.PROVIDER, PROVIDER_EXIT_CODE),
+        (ErrorCode.DATA_QUALITY, DATA_QUALITY_EXIT_CODE),
+        (ErrorCode.RECONCILE, RECONCILE_EXIT_CODE),
+        (ErrorCode.SYSTEM, SYSTEM_EXIT_CODE),
+    ],
+)
+def test_cli_commands_surface_domain_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    code: ErrorCode,
+    expected_exit: int,
+) -> None:
+    runner = CliRunner()
+
+    def controller_factory() -> object:
+        class Controller:
+            def promote(self, force: bool) -> None:
+                raise DummyDomainError("boom", code)
+
+        return Controller()
+
+    monkeypatch.setattr("vprism.cli.shadow.get_shadow_controller", controller_factory)
+
+    result = runner.invoke(app, ["shadow", "promote"])
+
+    assert result.exit_code == expected_exit
+
+    payload = json.loads(result.stderr.strip())
+    assert payload["code"] == code.value
+    assert payload["message"] == "boom"

--- a/vprism/cli/data.py
+++ b/vprism/cli/data.py
@@ -19,7 +19,8 @@ from vprism.core.models.response import DataResponse
 from vprism.core.services.data import DataService
 from vprism.core.services.symbol_normalization import get_symbol_normalizer
 
-from .constants import PROVIDER_EXIT_CODE, SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .constants import VALIDATION_EXIT_CODE
+from .errors import handle_cli_error
 from .utils import emit_error, prepare_output
 
 
@@ -90,8 +91,7 @@ def fetch_command(
     try:
         _ensure_symbols_resolvable(collected, market_type, asset_type)
     except UnresolvedSymbolError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=VALIDATION_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
 
     service = get_data_service()
     try:
@@ -106,14 +106,11 @@ def fetch_command(
             )
         )
     except DataValidationError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=VALIDATION_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except ProviderError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=PROVIDER_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except VPrismError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=SYSTEM_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except ValueError as error:
         emit_error(str(error), "VALIDATION_ERROR")
         raise typer.Exit(code=VALIDATION_EXIT_CODE) from error

--- a/vprism/cli/drift.py
+++ b/vprism/cli/drift.py
@@ -12,7 +12,8 @@ from vprism.core.models.market import MarketType, TimeFrame
 from vprism.core.services.data import DataService
 from vprism.core.services.drift import DriftResult, DriftService
 
-from .constants import DATA_QUALITY_EXIT_CODE, SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .constants import SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .errors import handle_cli_error
 from .utils import emit_error, prepare_output
 
 
@@ -90,11 +91,9 @@ def report_command(
     try:
         result = service.compute(symbol=symbol, market=market_type, window=window)
     except DriftComputationError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=DATA_QUALITY_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except VPrismError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=SYSTEM_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except Exception as error:  # pragma: no cover - defensive guard
         emit_error(str(error), "UNEXPECTED_ERROR")
         raise typer.Exit(code=SYSTEM_EXIT_CODE) from error

--- a/vprism/cli/errors.py
+++ b/vprism/cli/errors.py
@@ -1,0 +1,101 @@
+"""Shared CLI error handling utilities."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from vprism.core.exceptions.base import VPrismError
+from vprism.core.exceptions.codes import ErrorCode
+
+from .constants import (
+    DATA_QUALITY_EXIT_CODE,
+    PROVIDER_EXIT_CODE,
+    RECONCILE_EXIT_CODE,
+    SYSTEM_EXIT_CODE,
+    VALIDATION_EXIT_CODE,
+)
+from .utils import emit_error
+
+ErrorCodeLike = ErrorCode | str
+
+
+_ERROR_CODE_TO_EXIT: dict[str, int] = {
+    ErrorCode.VALIDATION.value: VALIDATION_EXIT_CODE,
+    ErrorCode.VALIDATION_ERROR.value: VALIDATION_EXIT_CODE,
+    ErrorCode.DATA_VALIDATION_ERROR.value: VALIDATION_EXIT_CODE,
+    ErrorCode.INVALID_QUERY.value: VALIDATION_EXIT_CODE,
+    ErrorCode.UNSUPPORTED_PARAMETERS.value: VALIDATION_EXIT_CODE,
+    ErrorCode.QUERY_ERROR.value: VALIDATION_EXIT_CODE,
+    "SYMBOL_UNRESOLVED": VALIDATION_EXIT_CODE,
+    ErrorCode.PROVIDER.value: PROVIDER_EXIT_CODE,
+    ErrorCode.PROVIDER_ERROR.value: PROVIDER_EXIT_CODE,
+    ErrorCode.PROVIDER_NOT_FOUND.value: PROVIDER_EXIT_CODE,
+    ErrorCode.PROVIDER_UNAVAILABLE.value: PROVIDER_EXIT_CODE,
+    ErrorCode.PROVIDER_TIMEOUT.value: PROVIDER_EXIT_CODE,
+    ErrorCode.ROUTING.value: PROVIDER_EXIT_CODE,
+    ErrorCode.AUTHENTICATION_ERROR.value: PROVIDER_EXIT_CODE,
+    ErrorCode.AUTHORIZATION_ERROR.value: PROVIDER_EXIT_CODE,
+    ErrorCode.API_KEY_INVALID.value: PROVIDER_EXIT_CODE,
+    ErrorCode.API_KEY_EXPIRED.value: PROVIDER_EXIT_CODE,
+    ErrorCode.RATE_LIMIT_ERROR.value: PROVIDER_EXIT_CODE,
+    ErrorCode.RATE_LIMIT_EXCEEDED.value: PROVIDER_EXIT_CODE,
+    ErrorCode.QUOTA_EXCEEDED.value: PROVIDER_EXIT_CODE,
+    ErrorCode.NO_CAPABLE_PROVIDER.value: PROVIDER_EXIT_CODE,
+    ErrorCode.NETWORK_ERROR.value: PROVIDER_EXIT_CODE,
+    ErrorCode.CONNECTION_TIMEOUT.value: PROVIDER_EXIT_CODE,
+    ErrorCode.CONNECTION_REFUSED.value: PROVIDER_EXIT_CODE,
+    ErrorCode.DNS_RESOLUTION_ERROR.value: PROVIDER_EXIT_CODE,
+    ErrorCode.DATA_QUALITY.value: DATA_QUALITY_EXIT_CODE,
+    ErrorCode.DATA_NOT_FOUND.value: DATA_QUALITY_EXIT_CODE,
+    ErrorCode.DATA_FORMAT_ERROR.value: DATA_QUALITY_EXIT_CODE,
+    ErrorCode.DATA_INCOMPLETE.value: DATA_QUALITY_EXIT_CODE,
+    "DRIFT_COMPUTATION_ERROR": DATA_QUALITY_EXIT_CODE,
+    ErrorCode.RECONCILE.value: RECONCILE_EXIT_CODE,
+    "RECONCILIATION_ERROR": RECONCILE_EXIT_CODE,
+    ErrorCode.SYSTEM.value: SYSTEM_EXIT_CODE,
+    ErrorCode.GENERAL_ERROR.value: SYSTEM_EXIT_CODE,
+    ErrorCode.CONFIGURATION_ERROR.value: SYSTEM_EXIT_CODE,
+    ErrorCode.INTERNAL_ERROR.value: SYSTEM_EXIT_CODE,
+    ErrorCode.UNEXPECTED_ERROR.value: SYSTEM_EXIT_CODE,
+}
+
+
+def _normalize_error_code(code: ErrorCodeLike) -> str:
+    if isinstance(code, ErrorCode):
+        return code.value
+    return str(code).upper()
+
+
+def _resolve_exit_code(code: str) -> int:
+    normalized = code.upper()
+    if normalized in _ERROR_CODE_TO_EXIT:
+        return _ERROR_CODE_TO_EXIT[normalized]
+    if "VALID" in normalized:
+        return VALIDATION_EXIT_CODE
+    if "PROVIDER" in normalized or "AUTH" in normalized or "NETWORK" in normalized:
+        return PROVIDER_EXIT_CODE
+    if "QUALITY" in normalized or "DRIFT" in normalized:
+        return DATA_QUALITY_EXIT_CODE
+    if "RECONCILE" in normalized:
+        return RECONCILE_EXIT_CODE
+    return SYSTEM_EXIT_CODE
+
+
+def map_exit_code(error_code: ErrorCodeLike) -> int:
+    """Map an error code string or :class:`ErrorCode` to a CLI exit code."""
+
+    normalized = _normalize_error_code(error_code)
+    return _resolve_exit_code(normalized)
+
+
+def handle_cli_error(error: VPrismError) -> int:
+    """Emit a structured error payload and return the process exit code."""
+
+    message = getattr(error, "message", str(error))
+    code = getattr(error, "error_code", ErrorCode.UNEXPECTED_ERROR.value)
+    details: Mapping[str, object] | None = getattr(error, "details", None)
+    emit_error(message, str(code), details=details)
+    return map_exit_code(code)
+
+
+__all__ = ["handle_cli_error", "map_exit_code"]

--- a/vprism/cli/reconciliation.py
+++ b/vprism/cli/reconciliation.py
@@ -15,7 +15,8 @@ from vprism.core.services.reconciliation import (
     ReconciliationStatus,
 )
 
-from .constants import RECONCILE_EXIT_CODE, SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .constants import SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .errors import handle_cli_error
 from .utils import emit_error, prepare_output
 
 
@@ -105,11 +106,9 @@ def run_command(
             sample_size=sample_size,
         )
     except ReconciliationError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=RECONCILE_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except VPrismError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=SYSTEM_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
     except Exception as error:  # pragma: no cover - defensive fallback
         emit_error(str(error), "UNEXPECTED_ERROR")
         raise typer.Exit(code=SYSTEM_EXIT_CODE) from error

--- a/vprism/cli/shadow.py
+++ b/vprism/cli/shadow.py
@@ -15,6 +15,7 @@ from vprism.core.services.shadow import (
 )
 
 from .constants import SYSTEM_EXIT_CODE, VALIDATION_EXIT_CODE
+from .errors import handle_cli_error
 from .utils import emit_error, prepare_output
 
 
@@ -127,8 +128,7 @@ def promote_command(
     try:
         controller.promote(force=force)
     except DomainError as exc:
-        emit_error(exc.message, exc.error_code, details=exc.details)
-        raise typer.Exit(code=VALIDATION_EXIT_CODE) from exc
+        raise typer.Exit(code=handle_cli_error(exc)) from exc
 
     typer.echo("Shadow path promoted.")
 

--- a/vprism/cli/symbol.py
+++ b/vprism/cli/symbol.py
@@ -11,8 +11,8 @@ from vprism.core.models.market import AssetType, MarketType
 from vprism.core.models.symbols import CanonicalSymbol
 from vprism.core.services.symbols import SymbolService
 
-from .constants import VALIDATION_EXIT_CODE
-from .utils import emit_error, prepare_output
+from .errors import handle_cli_error
+from .utils import prepare_output
 
 
 symbol_app = typer.Typer(help="Symbol utilities.")
@@ -50,8 +50,7 @@ def resolve_command(
     try:
         canonical = service.normalize(symbol, market_type, asset_type)
     except UnresolvedSymbolError as error:
-        emit_error(error.message, error.error_code, details=error.details)
-        raise typer.Exit(code=VALIDATION_EXIT_CODE) from error
+        raise typer.Exit(code=handle_cli_error(error)) from error
 
     rows = [_canonical_to_row(canonical)]
     try:


### PR DESCRIPTION
## Summary
- add a shared `handle_cli_error` helper that maps error codes to CLI exit codes and emits structured payloads
- route CLI commands through the centralized helper to ensure consistent exit behaviour
- add focused tests covering the handler and a CLI smoke test for error propagation

## Testing
- uv run pytest tests/cli/test_cli_error_handling.py

------
https://chatgpt.com/codex/tasks/task_e_68e622bd3cf0832d9c7aaa7b274ee03d